### PR TITLE
Return object from sendEvent

### DIFF
--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -102,12 +102,13 @@ export class AutoblocksTracer {
       timestamp?: string;
       properties?: EventProperties;
     },
-  ): Promise<string | undefined> {
+  ): Promise<{ traceId?: string }> {
     try {
-      return await this.sendEventUnsafe(message, args);
+      const traceId = await this.sendEventUnsafe(message, args);
+      return { traceId };
     } catch (err) {
       console.error(`Error sending event to Autoblocks: ${err}`);
-      return undefined;
+      return {};
     }
   }
 }

--- a/test/headers.spec.ts
+++ b/test/headers.spec.ts
@@ -36,7 +36,7 @@ describe('Replay Headers', () => {
     const commit = builder.getLocalCommitData({ sha: null });
 
     const ab = new AutoblocksTracer('mock-ingestion-token');
-    const traceId = await ab.sendEvent('mock-message');
+    const { traceId } = await ab.sendEvent('mock-message');
 
     expect(traceId).toEqual('mock-trace-id');
     expect(mockPost).toHaveBeenCalledWith(
@@ -102,7 +102,7 @@ describe('Replay Headers', () => {
       });
 
       const ab = new AutoblocksTracer('mock-ingestion-token');
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -167,7 +167,7 @@ describe('Replay Headers', () => {
       });
 
       const ab = new AutoblocksTracer('mock-ingestion-token');
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(

--- a/test/tracer.spec.ts
+++ b/test/tracer.spec.ts
@@ -52,7 +52,7 @@ describe('Autoblocks Tracer', () => {
 
     it('sends a message', async () => {
       const ab = new AutoblocksTracer('mock-ingestion-token');
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -70,7 +70,7 @@ describe('Autoblocks Tracer', () => {
     it('sends a message with properties', async () => {
       const ab = new AutoblocksTracer('mock-ingestion-token');
 
-      const traceId = await ab.sendEvent('mock-message', {
+      const { traceId } = await ab.sendEvent('mock-message', {
         properties: { x: 1 },
       });
 
@@ -92,7 +92,7 @@ describe('Autoblocks Tracer', () => {
         properties: { x: 1 },
       });
 
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -111,7 +111,7 @@ describe('Autoblocks Tracer', () => {
       const ab = new AutoblocksTracer('mock-ingestion-token');
       ab.setProperties({ x: 1 });
 
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -130,7 +130,7 @@ describe('Autoblocks Tracer', () => {
       const ab = new AutoblocksTracer('mock-ingestion-token');
       ab.updateProperties({ x: 1 });
 
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -151,7 +151,7 @@ describe('Autoblocks Tracer', () => {
       });
       ab.updateProperties({ x: 10 });
 
-      const traceId = await ab.sendEvent('mock-message', {
+      const { traceId } = await ab.sendEvent('mock-message', {
         properties: { y: 20 },
       });
 
@@ -175,7 +175,7 @@ describe('Autoblocks Tracer', () => {
       ab.updateProperties({ x: 10 });
       ab.setProperties({ x: 100 });
 
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
 
       expect(traceId).toEqual('mock-trace-id');
       expect(mockPost).toHaveBeenCalledWith(
@@ -274,7 +274,7 @@ describe('Autoblocks Tracer', () => {
       });
 
       const ab = new AutoblocksTracer('mock-ingestion-token');
-      const traceId = await ab.sendEvent('mock-message');
+      const { traceId } = await ab.sendEvent('mock-message');
       expect(traceId).toBeUndefined();
     });
   });


### PR DESCRIPTION
I'm thinking we should make this an object in case we ever want to add more info to this payload, e.g. the eventId