### PR TITLE
Give access to underlying tracer

### DIFF
--- a/test/langchain.spec.ts
+++ b/test/langchain.spec.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import { AutoblocksCallbackHandler } from '../src/langchain/index';
 
 import { LLMChain } from 'langchain/chains';
@@ -7,6 +9,11 @@ import { PromptTemplate } from 'langchain/prompts';
 import { ChatOpenAI } from 'langchain/chat_models/openai';
 import { RunnableSequence } from 'langchain/schema/runnable';
 import { StringOutputParser } from 'langchain/schema/output_parser';
+
+import { initializeAgentExecutorWithOptions } from 'langchain/agents';
+import { DynamicTool } from 'langchain/tools';
+
+jest.setTimeout(60000);
 
 // Used to verify we're sending the correct version
 // This will need to be updated if we update our version of
@@ -34,11 +41,11 @@ describe('AutoblocksCallbackHandler', () => {
   });
 
   it('openai llm chain', async () => {
-    const llm = new OpenAI({ temperature: 0, callbacks: [handler] });
+    const llm = new OpenAI({ temperature: 0 });
     const prompt = PromptTemplate.fromTemplate('2 + {number} =');
-    const chain = new LLMChain({ prompt, llm, callbacks: [handler] });
+    const chain = new LLMChain({ prompt, llm });
 
-    await chain.call({ number: 2 });
+    await chain.call({ number: 2 }, { callbacks: [handler] });
 
     const calls = mockPost.mock.calls;
     expect(calls.length).toEqual(4);
@@ -142,5 +149,130 @@ describe('AutoblocksCallbackHandler', () => {
     expect(
       properties.every((prop) => prop.__langchainLanguage === 'javascript'),
     ).toBe(true);
+  });
+
+  it('resets the traceId for each call', async () => {
+    const llm = new OpenAI({ temperature: 0 });
+    const prompt = PromptTemplate.fromTemplate('2 + {number} =');
+    const chain = new LLMChain({ prompt, llm });
+
+    // First call
+    await chain.call({ number: 2 }, { callbacks: [handler] });
+    // Second call
+    await chain.call({ number: 7 }, { callbacks: [handler] });
+
+    const calls = mockPost.mock.calls;
+    expect(calls.length).toEqual(8);
+
+    const messages = calls.map((call) => call[1].message);
+    const traceIds = calls.map((call) => call[1].traceId);
+
+    expect(messages).toEqual([
+      // First call
+      'langchain.chain.start',
+      'langchain.llm.start',
+      'langchain.llm.end',
+      'langchain.chain.end',
+      // Second call
+      'langchain.chain.start',
+      'langchain.llm.start',
+      'langchain.llm.end',
+      'langchain.chain.end',
+    ]);
+
+    // First four calls should have the same traceId
+    expect(traceIds.slice(0, 4).every(Boolean)).toBe(true);
+    expect(traceIds.slice(0, 4).every((id) => id === traceIds[0])).toBe(true);
+    // Last four calls should have the same traceId
+    expect(traceIds.slice(4).every(Boolean)).toBe(true);
+    expect(traceIds.slice(4).every((id) => id === traceIds[4])).toBe(true);
+    // First and last traceIds should be different
+    expect(traceIds[0]).not.toEqual(traceIds[4]);
+  });
+
+  it('gives access to the tracer', async () => {
+    const llm = new OpenAI({ temperature: 0 });
+    const prompt = PromptTemplate.fromTemplate('2 + {number} =');
+    const chain = new LLMChain({ prompt, llm });
+
+    const mockTraceId = crypto.randomUUID();
+    // Set the trace id via the tracer on the handler
+    handler.tracer.setTraceId(mockTraceId);
+
+    await chain.call({ number: 2 }, { callbacks: [handler] });
+
+    // Send a custom event via the tracer on the handler
+    await handler.tracer.sendEvent('my.custom.event');
+
+    const calls = mockPost.mock.calls;
+    expect(calls.length).toEqual(5);
+
+    const messages = calls.map((call) => call[1].message);
+    const traceIds = calls.map((call) => call[1].traceId);
+
+    expect(messages).toEqual([
+      'langchain.chain.start',
+      'langchain.llm.start',
+      'langchain.llm.end',
+      'langchain.chain.end',
+      'my.custom.event',
+    ]);
+
+    // All events (including the custom event) should have the same traceId
+    expect(traceIds.every((traceId) => traceId === mockTraceId)).toBe(true);
+  });
+
+  it('works with agents and tools', async () => {
+    const model = new OpenAI({ temperature: 0 });
+    const tools = [
+      new DynamicTool({
+        name: 'FOO',
+        description:
+          'call this to get the value of foo. input should be an empty string.',
+        func: async () => 'baz',
+      }),
+      new DynamicTool({
+        name: 'BAR',
+        description:
+          'call this to get the value of bar. input should be an empty string.',
+        func: async () => 'baz1',
+      }),
+    ];
+
+    const executor = await initializeAgentExecutorWithOptions(tools, model, {
+      agentType: 'zero-shot-react-description',
+    });
+
+    await executor.call(
+      { input: 'What is the value of foo?' },
+      { callbacks: [handler] },
+    );
+
+    const calls = mockPost.mock.calls;
+    expect(calls.length).toEqual(14);
+
+    const messages = calls.map((call) => call[1].message);
+    const traceIds = calls.map((call) => call[1].traceId);
+
+    expect(messages).toEqual([
+      'langchain.chain.start',
+      'langchain.chain.start',
+      'langchain.llm.start',
+      'langchain.llm.end',
+      'langchain.chain.end',
+      'langchain.agent.action',
+      'langchain.tool.start',
+      'langchain.tool.end',
+      'langchain.chain.start',
+      'langchain.llm.start',
+      'langchain.llm.end',
+      'langchain.chain.end',
+      'langchain.agent.end',
+      'langchain.chain.end',
+    ]);
+
+    // All traceIds should be equal and defined
+    expect(traceIds.every(Boolean)).toBe(true);
+    expect(traceIds.every((id) => id === traceIds[0])).toBe(true);
   });
 });


### PR DESCRIPTION
* gives access to the underlying tracer so you can set your own traceId + send custom events
* also fixed agent callbacks and added a test for agents/tools