### PR TITLE
Use import instead of require

### DIFF
--- a/src/openai.ts
+++ b/src/openai.ts
@@ -60,9 +60,8 @@ function makeWrapper(func: any): any {
   };
 }
 
-function patch() {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const openAiModule: typeof import('openai') = require('openai');
+async function patch() {
+  const openAiModule = await import('openai');
   openAiModule.OpenAI.Completions.prototype.create = makeWrapper(
     openAiModule.OpenAI.Completions.prototype.create,
   );
@@ -71,7 +70,7 @@ function patch() {
   );
 }
 
-export function traceOpenAI(): AutoblocksTracer {
+export async function traceOpenAI(): Promise<AutoblocksTracer> {
   if (traceOpenAI.called) {
     return tracer;
   }
@@ -83,9 +82,9 @@ export function traceOpenAI(): AutoblocksTracer {
   }
 
   try {
-    patch();
-  } catch {
-    console.warn("Couldn't patch openai module");
+    await patch();
+  } catch (err) {
+    console.warn(`Couldn't patch openai module: ${err}`);
   }
 
   traceOpenAI.called = true;

--- a/test/openai.spec.ts
+++ b/test/openai.spec.ts
@@ -1,17 +1,21 @@
 import crypto from 'crypto';
 import { OpenAI } from 'openai';
-import { traceOpenAI } from '../src';
+import { AutoblocksTracer, traceOpenAI } from '../src';
 
 jest.setTimeout(10000);
 
 describe('traceOpenAI', () => {
   process.env.AUTOBLOCKS_INGESTION_KEY = 'test';
 
-  const tracer = traceOpenAI();
+  let tracer: AutoblocksTracer;
 
-  // Call multiple times to make sure we aren't patching openai multiple times
-  traceOpenAI();
-  traceOpenAI();
+  beforeAll(async () => {
+    tracer = await traceOpenAI();
+
+    // Call multiple times to make sure the patch is idempotent
+    await traceOpenAI();
+    await traceOpenAI();
+  });
 
   const openai = new OpenAI();
 


### PR DESCRIPTION
Tried adding an example of `traceOpenAI` to the examples repo but it seems esbuild (which tsup uses under the hood) can't handle the dynamic require: https://github.com/evanw/esbuild/issues/1921

Tested this version with yalc and seems to be working