### PR TITLE
Add top-level sendEvent args for spanId + parentSpanId

### DIFF
--- a/src/openai/index.ts
+++ b/src/openai/index.ts
@@ -30,7 +30,8 @@ function makeWrapper(func: any): any {
 
     await tracer.sendEvent('ai.completion.request', {
       traceId,
-      properties: { spanId, ...args[0] },
+      spanId,
+      properties: args[0],
     });
 
     const start = Date.now();
@@ -47,19 +48,19 @@ function makeWrapper(func: any): any {
       if (error) {
         await tracer.sendEvent('ai.completion.error', {
           traceId,
+          spanId,
           properties: {
             latencyMs,
             error: error.toString(),
-            spanId,
           },
         });
       } else {
         await tracer.sendEvent('ai.completion.response', {
           traceId,
+          spanId,
           properties: {
             latencyMs,
             response,
-            spanId,
           },
         });
       }

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -54,6 +54,8 @@ export class AutoblocksTracer {
     message: string,
     args?: {
       traceId?: string;
+      spanId?: string;
+      parentSpanId?: string;
       timestamp?: string;
       properties?: EventProperties;
     },
@@ -63,6 +65,8 @@ export class AutoblocksTracer {
     const properties = {
       ...this.properties,
       ...(args?.properties || {}),
+      spanId: args?.spanId,
+      parentSpanId: args?.parentSpanId,
     };
 
     let replayHeaders = undefined;
@@ -90,6 +94,8 @@ export class AutoblocksTracer {
     message: string,
     args?: {
       traceId?: string;
+      spanId?: string;
+      parentSpanId?: string;
       timestamp?: string;
       properties?: EventProperties;
     },

--- a/test/tracer.spec.ts
+++ b/test/tracer.spec.ts
@@ -278,6 +278,70 @@ describe('Autoblocks Tracer', () => {
         { headers: undefined },
       );
     });
+
+    it('sends the spanId as a property', async () => {
+      const tracer = new AutoblocksTracer('mock-ingestion-token');
+
+      await tracer.sendEvent('mock-message', {
+        traceId: 'my-trace-id',
+        spanId: 'my-span-id',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/',
+        {
+          message: 'mock-message',
+          traceId: 'my-trace-id',
+          timestamp,
+          properties: { spanId: 'my-span-id' },
+        },
+        { headers: undefined },
+      );
+    });
+
+    it('sends the parentSpanId as a property', async () => {
+      const tracer = new AutoblocksTracer('mock-ingestion-token');
+
+      await tracer.sendEvent('mock-message', {
+        traceId: 'my-trace-id',
+        parentSpanId: 'my-parent-span-id',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/',
+        {
+          message: 'mock-message',
+          traceId: 'my-trace-id',
+          timestamp,
+          properties: { parentSpanId: 'my-parent-span-id' },
+        },
+        { headers: undefined },
+      );
+    });
+
+    it('sends the spanId and parentSpanId as a property', async () => {
+      const tracer = new AutoblocksTracer('mock-ingestion-token');
+
+      await tracer.sendEvent('mock-message', {
+        traceId: 'my-trace-id',
+        spanId: 'my-span-id',
+        parentSpanId: 'my-parent-span-id',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith(
+        '/',
+        {
+          message: 'mock-message',
+          traceId: 'my-trace-id',
+          timestamp,
+          properties: {
+            spanId: 'my-span-id',
+            parentSpanId: 'my-parent-span-id',
+          },
+        },
+        { headers: undefined },
+      );
+    });
   });
 
   describe('Error Handling', () => {


### PR DESCRIPTION
Adding as a top-level arg to `sendEvent` but continuing to send as a property until we add support for it as a top-level field like `traceId`