### PR TITLE
Update type for properties

### DIFF
--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -9,7 +9,11 @@ import {
   LLMResult,
 } from 'langchain/dist/schema';
 import { AutoblocksTracer } from '../tracer';
-import { AUTOBLOCKS_INGESTION_KEY, readEnv } from '../util';
+import {
+  AUTOBLOCKS_INGESTION_KEY,
+  type ArbitraryProperties,
+  readEnv,
+} from '../util';
 
 export class AutoblocksCallbackHandler extends BaseCallbackHandler {
   name = 'autoblocks_handler';
@@ -82,7 +86,7 @@ export class AutoblocksCallbackHandler extends BaseCallbackHandler {
 
   private async sendEvent(
     messageParts: string[],
-    properties: Record<string, unknown>,
+    properties: ArbitraryProperties,
   ) {
     const message = [this.messagePrefix, ...messageParts]
       .filter(Boolean)

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -19,7 +19,7 @@ interface SendEventArgs {
 export class AutoblocksTracer {
   private client: AxiosInstance;
   private _traceId: string | undefined;
-  private properties: Record<string, unknown>;
+  private properties: ArbitraryProperties;
 
   constructor(
     ingestionToken: string,

--- a/src/util.ts
+++ b/src/util.ts
@@ -320,7 +320,10 @@ export const convertTimeDeltaToMilliSeconds = (delta: TimeDelta): number => {
   return totalSeconds * 1000 + milliseconds;
 };
 
-export type ArbitraryProperties = Record<string | number, unknown>;
+// Use any here so that interfaces can be assigned to this type.
+// https://stackoverflow.com/q/65799316
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ArbitraryProperties = Record<string | number, any>;
 
 export interface PromptTracking {
   id: string | number;

--- a/test/tracer.spec.ts
+++ b/test/tracer.spec.ts
@@ -500,4 +500,23 @@ describe('Autoblocks Tracer', () => {
       expect(traceId).toBeUndefined();
     });
   });
+
+  describe('Types', () => {
+    it('allows sending an interface as properties', async () => {
+      interface Something {
+        x: string;
+      }
+
+      const something: Something = { x: 'hello' };
+
+      const tracer = new AutoblocksTracer('mock-ingestion-token');
+
+      await tracer.sendEvent('mock-message', {
+        traceId: 'my-trace-id',
+        properties: something,
+      });
+
+      // No assertions necessary, this test is just checking that the types work
+    });
+  });
 });


### PR DESCRIPTION
Interfaces can't be assigned to `Record<string, unknown>` but it works if it's `Record<string, any>`. This is an issue if e.g. you're trying to send your openai request as properties, which is why I had to spread it here: https://github.com/autoblocksai/autoblocks-examples/blob/df99efecf49fa0150f17f232df6f223ecc8e5886/JavaScript/prompt-sdk/src/index.ts#L54-L56

https://stackoverflow.com/questions/65799316/why-cant-an-interface-be-assigned-to-recordstring-unknown