### PR TITLE
Only send first line of commit message

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -250,8 +250,10 @@ export class HeadersBuilder {
       const [key, value] = [line.slice(0, idx), line.slice(idx + 1)];
 
       if (key === commitMessageKey) {
-        // Once we've reached the commit message key, the remaining lines are the commit message
-        data[commitMessageKey] = [value, ...lines].join('\n');
+        // Once we've reached the commit message key, the remaining lines are the commit message.
+        // We only keep the first line of the commit message, though, since some commit
+        // messages can be very long.
+        data[commitMessageKey] = value;
         break;
       }
 

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -7,6 +7,7 @@ describe('Headers Builder', () => {
 
     expect(commit.sha.length).toEqual(40);
     expect(commit.message.length).toBeGreaterThan(0);
+    expect(commit.message.includes('\n')).toBe(false);
     expect(commit.committerName.length).toBeGreaterThan(0);
     expect(commit.authorName.length).toBeGreaterThan(0);
     expect(commit.authorEmail.includes('@')).toBe(true);


### PR DESCRIPTION
The replays in autoblocks-examples aren't working because the current commit message on main is too long

https://github.com/autoblocksai/autoblocks-examples/commit/9438222aa9de0e56fdb24df1bb01cad9487aae4a