### PR TITLE
Allow settings keys with environment variables

### DIFF
--- a/src/ai-jsx/util.ts
+++ b/src/ai-jsx/util.ts
@@ -559,7 +559,7 @@ export async function sendAutoblocksEventsForCompletedRootSpan(
     return;
   }
 
-  const tracer = new AutoblocksTracer(ingestionKey);
+  const tracer = new AutoblocksTracer({ ingestionKey });
   await Promise.all(
     events.map((event) => tracer.sendEvent(event.message, event.args)),
   );

--- a/src/client.ts
+++ b/src/client.ts
@@ -87,13 +87,7 @@ export class AutoblocksAPIClient {
   private client: AxiosInstance;
 
   // Deprecated constructor
-  constructor(
-    apiKey: string,
-    args?: {
-      apiKey?: string;
-      timeout?: TimeDelta;
-    },
-  );
+  constructor(apiKey: string, args?: ClientArgs);
   // Current constructor
   constructor(args?: ClientArgs);
   constructor(keyOrArgs?: string | ClientArgs, maybeArgs?: ClientArgs) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,10 @@
 import axios, { AxiosInstance } from 'axios';
-import { type TimeDelta, convertTimeDeltaToMilliSeconds } from './util';
+import {
+  type TimeDelta,
+  convertTimeDeltaToMilliSeconds,
+  readEnv,
+  AUTOBLOCKS_API_KEY,
+} from './util';
 
 export interface View {
   id: string;
@@ -73,19 +78,39 @@ export enum SystemEventFilterKey {
   LABEL = 'SYSTEM:label',
 }
 
+interface ClientArgs {
+  apiKey?: string;
+  timeout?: TimeDelta;
+}
+
 export class AutoblocksAPIClient {
   private client: AxiosInstance;
 
+  // Deprecated constructor
   constructor(
-    apiToken: string,
+    apiKey: string,
     args?: {
+      apiKey?: string;
       timeout?: TimeDelta;
     },
-  ) {
+  );
+  // Current constructor
+  constructor(args?: ClientArgs);
+  constructor(keyOrArgs?: string | ClientArgs, maybeArgs?: ClientArgs) {
+    const args = typeof keyOrArgs === 'string' ? maybeArgs : keyOrArgs;
+    const key =
+      typeof keyOrArgs === 'string'
+        ? keyOrArgs
+        : args?.apiKey || readEnv(AUTOBLOCKS_API_KEY);
+    if (!key) {
+      throw new Error(
+        `You must either pass in the API key via 'apiKey' or set the '${AUTOBLOCKS_API_KEY}' environment variable.`,
+      );
+    }
     this.client = axios.create({
       baseURL: 'https://api.autoblocks.ai',
       headers: {
-        Authorization: `Bearer ${apiToken}`,
+        Authorization: `Bearer ${key}`,
       },
       timeout: convertTimeDeltaToMilliSeconds(args?.timeout || { seconds: 10 }),
     });

--- a/src/langchain/index.ts
+++ b/src/langchain/index.ts
@@ -40,7 +40,8 @@ export class AutoblocksCallbackHandler extends BaseCallbackHandler {
       // Couldn't determine version
     }
 
-    this._tracer = new AutoblocksTracer(ingestionKey, {
+    this._tracer = new AutoblocksTracer({
+      ingestionKey,
       properties: {
         __langchainVersion: langchainVersion,
         __langchainLanguage: 'javascript',

--- a/src/tracer.ts
+++ b/src/tracer.ts
@@ -4,27 +4,42 @@ import {
   type TimeDelta,
   convertTimeDeltaToMilliSeconds,
   readEnv,
+  AUTOBLOCKS_INGESTION_KEY,
   AUTOBLOCKS_TRACER_THROW_ON_ERROR,
 } from './util';
 import type { ArbitraryProperties, SendEventArgs } from './types';
+
+interface TracerArgs {
+  ingestionKey?: string;
+  traceId?: string;
+  properties?: ArbitraryProperties;
+  timeout?: TimeDelta;
+}
 
 export class AutoblocksTracer {
   private client: AxiosInstance;
   private _traceId: string | undefined;
   private properties: ArbitraryProperties;
 
-  constructor(
-    ingestionToken: string,
-    args?: {
-      traceId?: string;
-      properties?: ArbitraryProperties;
-      timeout?: TimeDelta;
-    },
-  ) {
+  // Deprecated constructor
+  constructor(ingestionKey?: string, args?: TracerArgs);
+  // Current constructor
+  constructor(args?: TracerArgs);
+  constructor(keyOrArgs?: string | TracerArgs, maybeArgs?: TracerArgs) {
+    const args = typeof keyOrArgs === 'string' ? maybeArgs : keyOrArgs;
+    const key =
+      typeof keyOrArgs === 'string'
+        ? keyOrArgs
+        : args?.ingestionKey || readEnv(AUTOBLOCKS_INGESTION_KEY);
+    if (!key) {
+      throw new Error(
+        `You must either pass in the ingestion key via 'ingestionKey' or set the '${AUTOBLOCKS_INGESTION_KEY}' environment variable.`,
+      );
+    }
     this.client = axios.create({
       baseURL: 'https://ingest-event.autoblocks.ai',
       headers: {
-        Authorization: `Bearer ${ingestionToken}`,
+        Authorization: `Bearer ${key}`,
       },
       timeout: convertTimeDeltaToMilliSeconds(args?.timeout || { seconds: 5 }),
     });

--- a/src/util.ts
+++ b/src/util.ts
@@ -301,6 +301,7 @@ export const makeReplayHeaders = (): Record<string, string> | undefined => {
   return builder.makeReplayHeaders();
 };
 
+export const AUTOBLOCKS_API_KEY = 'AUTOBLOCKS_API_KEY';
 export const AUTOBLOCKS_INGESTION_KEY = 'AUTOBLOCKS_INGESTION_KEY';
 export const AUTOBLOCKS_TRACER_THROW_ON_ERROR =
   'AUTOBLOCKS_TRACER_THROW_ON_ERROR';

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -1,20 +1,49 @@
 import axios from 'axios';
 import { AutoblocksAPIClient } from '../src/index';
+import { AUTOBLOCKS_API_KEY } from '../src/util';
 
 jest.mock('axios');
 
 describe('Autoblocks Client', () => {
   describe('constructor', () => {
-    it('creates a client with the correct parameters', () => {
-      new AutoblocksAPIClient('mock-api-token');
+    it('accepts api key as first arg (deprecated constructor)', () => {
+      new AutoblocksAPIClient('mock-api-key');
 
       expect(axios.create).toHaveBeenCalledWith({
         baseURL: 'https://api.autoblocks.ai',
         headers: {
-          Authorization: 'Bearer mock-api-token',
+          Authorization: 'Bearer mock-api-key',
         },
         timeout: 10000,
       });
+    });
+
+    it('accepts api key in args', () => {
+      new AutoblocksAPIClient({ apiKey: 'mock-api-key' });
+
+      expect(axios.create).toHaveBeenCalledWith({
+        baseURL: 'https://api.autoblocks.ai',
+        headers: {
+          Authorization: 'Bearer mock-api-key',
+        },
+        timeout: 10000,
+      });
+    });
+
+    it('accepts api key as environment variable', () => {
+      process.env[AUTOBLOCKS_API_KEY] = 'mock-api-key';
+
+      new AutoblocksAPIClient();
+
+      expect(axios.create).toHaveBeenCalledWith({
+        baseURL: 'https://api.autoblocks.ai',
+        headers: {
+          Authorization: 'Bearer mock-api-key',
+        },
+        timeout: 10000,
+      });
+
+      delete process.env[AUTOBLOCKS_API_KEY];
     });
 
     it.each([
@@ -23,13 +52,34 @@ describe('Autoblocks Client', () => {
       [{ milliseconds: 1 }, 1],
       [{ seconds: 1, milliseconds: 1 }, 1001],
       [{ minutes: 1, seconds: 1, milliseconds: 1 }, 61001],
+    ])(
+      "sets the correct timeout for '%s' (deprecated constructor)",
+      (timeout, expected) => {
+        new AutoblocksAPIClient('mock-api-token', { timeout });
+
+        expect(axios.create).toHaveBeenCalledWith({
+          baseURL: 'https://api.autoblocks.ai',
+          headers: {
+            Authorization: 'Bearer mock-api-token',
+          },
+          timeout: expected,
+        });
+      },
+    );
+
+    it.each([
+      [{ minutes: 1 }, 60000],
+      [{ seconds: 1 }, 1000],
+      [{ milliseconds: 1 }, 1],
+      [{ seconds: 1, milliseconds: 1 }, 1001],
+      [{ minutes: 1, seconds: 1, milliseconds: 1 }, 61001],
     ])("sets the correct timeout for '%s'", (timeout, expected) => {
-      new AutoblocksAPIClient('mock-api-token', { timeout });
+      new AutoblocksAPIClient({ apiKey: 'mock-api-key', timeout });
 
       expect(axios.create).toHaveBeenCalledWith({
         baseURL: 'https://api.autoblocks.ai',
         headers: {
-          Authorization: 'Bearer mock-api-token',
+          Authorization: 'Bearer mock-api-key',
         },
         timeout: expected,
       });


### PR DESCRIPTION
Allows setting the API key / ingestion key as environment variables so you can initialize the classes w/o any args:

```ts
const tracer = new AutoblocksTracer();
const client = new AutoblocksAPIClient();
```