### PR TITLE
Fix security alert

### DIFF
--- a/e2e/test-local-prompt-manager-ts/package-lock.json
+++ b/e2e/test-local-prompt-manager-ts/package-lock.json
@@ -13,7 +13,8 @@
         "jest": "*",
         "nodemon": "*",
         "openai": "*",
-        "ts-jest": "*"
+        "ts-jest": "*",
+        "typescript": "*"
       },
       "engines": {
         "node": ">=18"
@@ -1071,10 +1072,11 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.6.1",
-      "license": "MIT",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
+      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1651,14 +1653,15 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -3096,7 +3099,8 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -3485,7 +3489,6 @@
     "node_modules/typescript": {
       "version": "5.2.2",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3657,7 +3660,8 @@
     },
     "node_modules/zod": {
       "version": "3.22.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.4.0",
+        "axios": "^1.6.5",
         "zod": "^3.21.4"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "typescript": "^5.1.6"
   },
   "dependencies": {
-    "axios": "^1.4.0",
+    "axios": "^1.6.5",
     "zod": "^3.21.4"
   }
 }


### PR DESCRIPTION
Updating the range for axios so that it always installs at least 1.6.5 which contains a security fix