### PR TITLE
send params as-is

### DIFF
--- a/e2e/test-prompt-manager-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-ts/test/index.spec.ts
@@ -79,13 +79,16 @@ describe('AutoblocksPromptManager v1.0', () => {
           },
         ],
         params: {
-          frequencyPenalty: 0,
-          maxTokens: 256,
-          model: 'gpt-4',
-          presencePenalty: 0.3,
-          stopSequences: [],
-          temperature: 0.7,
-          topP: 1,
+          version: '1.0',
+          params: {
+            frequencyPenalty: 0,
+            maxTokens: 256,
+            model: 'gpt-4',
+            presencePenalty: 0.3,
+            stopSequences: [],
+            temperature: 0.7,
+            topP: 1,
+          },
         },
       });
     });
@@ -155,13 +158,16 @@ describe('AutoblocksPromptManager v1 latest', () => {
           },
         ],
         params: {
-          frequencyPenalty: 0,
-          maxTokens: 256,
-          model: 'gpt-4',
-          presencePenalty: -0.3,
-          stopSequences: [],
-          temperature: 0.7,
-          topP: 1,
+          version: '1.1',
+          params: {
+            frequencyPenalty: 0,
+            maxTokens: 256,
+            model: 'gpt-4',
+            presencePenalty: -0.3,
+            stopSequences: [],
+            temperature: 0.7,
+            topP: 1,
+          },
         },
       });
     });
@@ -271,13 +277,16 @@ describe('AutoblocksPromptManager v2.1', () => {
           },
         ],
         params: {
-          frequencyPenalty: 0,
-          maxTokens: 256,
-          model: 'gpt-4',
-          presencePenalty: -0.3,
-          stopSequences: [],
-          temperature: 0.7,
-          topP: 1,
+          version: '1.1',
+          params: {
+            frequencyPenalty: 0,
+            maxTokens: 256,
+            model: 'gpt-4',
+            presencePenalty: -0.3,
+            stopSequences: [],
+            temperature: 0.7,
+            topP: 1,
+          },
         },
       });
     });

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -328,7 +328,7 @@ class PromptRenderer<
       id: this.prompt.id,
       version: this.prompt.version,
       templates: this.prompt.templates,
-      params: this.prompt.params?.params ?? undefined,
+      params: this.prompt.params ?? undefined,
     };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,10 @@ export interface PromptTracking {
     version: string;
     template: string;
   }[];
-  params?: Record<string, unknown>;
+  params?: {
+    version: string;
+    params: Record<string, unknown>;
+  };
 }
 
 export interface TimeDelta {

--- a/test/tracer.spec.ts
+++ b/test/tracer.spec.ts
@@ -428,7 +428,10 @@ describe('Autoblocks Tracer', () => {
             },
           ],
           params: {
-            x: 1,
+            version: '1.2',
+            params: {
+              x: 1,
+            },
           },
         },
       });
@@ -450,7 +453,10 @@ describe('Autoblocks Tracer', () => {
               },
             ],
             params: {
-              x: 1,
+              version: '1.2',
+              params: {
+                x: 1,
+              },
             },
           },
         },


### PR DESCRIPTION
decided to send the params as-is so that it matches the schema of our REST API, i think easier that way. also consistent with how we send the templates (which includes the version)