### PR TITLE
Drop flush logs

### DIFF
--- a/src/tracer/tracer.ts
+++ b/src/tracer/tracer.ts
@@ -292,18 +292,10 @@ export async function flush(timeout?: TimeDelta): Promise<void> {
   const timeoutMilliseconds = convertTimeDeltaToMilliSeconds(
     timeout || { seconds: 30 },
   );
-  console.debug(
-    `Flushing background tasks with timeout of ${timeoutMilliseconds}ms.`,
-  );
 
   if (backgroundTasks.size === 0) {
-    console.debug('No background tasks to flush.');
     return;
   }
-
-  console.debug(
-    `Waiting for ${backgroundTasks.size} background tasks to finish...`,
-  );
 
   const startTime = Date.now();
   while (
@@ -317,7 +309,5 @@ export async function flush(timeout?: TimeDelta): Promise<void> {
     console.error(
       `Timed out waiting for background tasks to flush. ${backgroundTasks.size} tasks left unfinished.`,
     );
-  } else {
-    console.debug('Successfully flushed all background tasks.');
   }
 }


### PR DESCRIPTION
in python we use the debug level here so that users won't see these unless they have their log level set to debug. but in node the logging landscape is much more fragmented, so dropping these for now since i'm not sure what best practices are here

as-is it spams the logs when running tests

<img width="639" alt="Screenshot 2024-03-28 at 1 21 58 PM" src="https://github.com/autoblocksai/javascript-sdk/assets/7498009/78b2a2e9-f734-4b4c-81c8-7533925d63e6">
