### PR TITLE
Add generic types to get test cases

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -40,9 +40,9 @@ export interface Trace {
   events: Event[];
 }
 
-export interface ManagedTestCase {
+export interface ManagedTestCase<T> {
   id: string;
-  body: Record<string, unknown>;
+  body: T;
 }
 
 interface RelativeTimeFilter {
@@ -199,9 +199,9 @@ export class AutoblocksAPIClient {
     return this.get(`/datasets/${args.datasetId}`);
   }
 
-  public async getTestCases(args: {
+  public async getTestCases<T>(args: {
     testSuiteId: string;
-  }): Promise<{ testCases: ManagedTestCase[] }> {
+  }): Promise<{ testCases: ManagedTestCase<T>[] }> {
     return this.get(`/test-suites/${args.testSuiteId}/test-cases`);
   }
 }

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -110,4 +110,24 @@ describe('Autoblocks Client', () => {
       });
     });
   });
+
+  describe('getTestCases', () => {
+    it('Should fetch test cases', async () => {
+      mockFetch = jest
+        .spyOn(global, 'fetch')
+        // @ts-expect-error - Only need json
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              testCases: [{ id: '123', body: { input: 'test' } }],
+            }),
+        });
+      const client = new AutoblocksAPIClient('mock-api-key');
+      const testCaseResult = await client.getTestCases<{ input: string }>({
+        testSuiteId: 'something',
+      });
+      expect(testCaseResult.testCases[0].body.input).toEqual('test');
+    });
+  });
 });


### PR DESCRIPTION
* Added generic type to AutoblocksApiClient.getTestCases
* Create unit test for fetching test cases


Docs update: https://github.com/autoblocksai/autoblocks-docs/pull/220