### PR TITLE
Fix pinned undeployed

### DIFF
--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -101,7 +101,6 @@ export class AutoblocksPromptManager<
     this.majorVersion = args.version.major;
     this.minorVersion = args.version.minor;
     this.minorVersionsToRequest = makeMinorVersionsToRequest({
-      majorVersion: this.majorVersion,
       minorVersion: this.minorVersion,
     });
 
@@ -379,12 +378,8 @@ export class AutoblocksPromptManager<
     if (isTestingContext() && this.promptRevisionOverride) {
       // Always use the prompt revision override if it is set
       return this.promptRevisionOverride;
-    } else if (
-      this.majorVersion ===
-      RevisionSpecialVersionsEnum.DANGEROUSLY_USE_UNDEPLOYED
-    ) {
-      return this.prompts[REVISION_UNDEPLOYED_VERSION];
-    } else if (Array.isArray(this.minorVersion)) {
+    }
+    if (Array.isArray(this.minorVersion)) {
       const weightTotal = this.minorVersion.reduce(
         (acc, cur) => acc + cur.weight,
         0,
@@ -474,15 +469,10 @@ class PromptExecutionContext<
 }
 
 function makeMinorVersionsToRequest(args: {
-  majorVersion: string;
   minorVersion: string | { version: string }[];
 }): string[] {
   const versions: Set<string> = new Set();
-  if (
-    args.majorVersion === RevisionSpecialVersionsEnum.DANGEROUSLY_USE_UNDEPLOYED
-  ) {
-    versions.add(REVISION_UNDEPLOYED_VERSION);
-  } else if (Array.isArray(args.minorVersion)) {
+  if (Array.isArray(args.minorVersion)) {
     args.minorVersion.forEach((minor) => {
       versions.add(minor.version);
     });

--- a/test/configs/config.spec.ts
+++ b/test/configs/config.spec.ts
@@ -38,12 +38,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig),
-      });
+      } as Response);
 
       await config.activateFromRemote({
         config: {
@@ -80,12 +79,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig),
-      });
+      } as Response);
 
       await config.activateFromRemote({
         config: {
@@ -120,12 +118,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig2),
-      });
+      } as Response);
       const sleep = (ms: number) =>
         new Promise((resolve) => setTimeout(resolve, ms));
       await sleep(1_001);
@@ -149,12 +146,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig),
-      });
+      } as Response);
 
       await config.activateFromRemote({
         config: {
@@ -188,12 +184,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig2),
-      });
+      } as Response);
       const sleep = (ms: number) =>
         new Promise((resolve) => setTimeout(resolve, ms));
       await sleep(1_001);
@@ -219,12 +214,11 @@ describe('AutoblocksConfig', () => {
           },
         ],
       };
-      // @ts-expect-error we don't need to mock everything here...
       mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockConfig),
-      });
+      } as Response);
 
       await config.activateFromRemote({
         config: {
@@ -270,12 +264,11 @@ describe('AutoblocksConfig', () => {
             },
           ],
         };
-        // @ts-expect-error we don't need to mock everything here...
         mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           ok: true,
           json: () => Promise.resolve(mockConfig),
-        });
+        } as Response);
 
         await config.activateFromRemote({
           config: {
@@ -315,12 +308,11 @@ describe('AutoblocksConfig', () => {
             },
           ],
         };
-        // @ts-expect-error we don't need to mock everything here...
         mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           ok: true,
           json: () => Promise.resolve(mockConfig),
-        });
+        } as Response);
 
         await config.activateFromRemote({
           config: {
@@ -363,12 +355,11 @@ describe('AutoblocksConfig', () => {
             },
           ],
         };
-        // @ts-expect-error we don't need to mock everything here...
         mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           ok: true,
           json: () => Promise.resolve(mockConfig),
-        });
+        } as Response);
 
         await config.activateFromRemote({
           config: {
@@ -407,12 +398,11 @@ describe('AutoblocksConfig', () => {
             },
           ],
         };
-        // @ts-expect-error we don't need to mock everything here...
         mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           ok: true,
           json: () => Promise.resolve(mockConfig),
-        });
+        } as Response);
 
         await config.activateFromRemote({
           config: {
@@ -458,12 +448,11 @@ describe('AutoblocksConfig', () => {
             },
           ],
         };
-        // @ts-expect-error we don't need to mock everything here...
         mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
           status: 200,
           ok: true,
           json: () => Promise.resolve(mockConfig),
-        });
+        } as Response);
 
         await config.activateFromRemote({
           config: {


### PR DESCRIPTION
we were requesting `https://api.autoblocks.ai/prompts/used-by-ci-dont-delete/major/undeployed/minor/undeployed` instead of `https://api.autoblocks.ai/prompts/used-by-ci-dont-delete/major/undeployed/minor/clvig4j4l0003tskj39y42nys` since we were overriding the minorVersion to "undeployed" if the majorVersion was "dangerously-use-undeployed"