### PR TITLE
update default base llm judge

### DIFF
--- a/src/testing/evaluators/llm-judge.ts
+++ b/src/testing/evaluators/llm-judge.ts
@@ -60,9 +60,9 @@ export abstract class BaseLLMJudge<
    * The model to use for the evaluator.
    * It must be an OpenAI model that supports tools.
    *
-   * @default "gpt-4-turbo".
+   * @default "gpt-4o".
    */
-  model = 'gpt-4-turbo';
+  model = 'gpt-4o';
   /**
    * The number of recent evaluation overrides to fetch for the evaluator and pass to make_prompt.
    *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the default model used for evaluations from 'gpt-4-turbo' to 'gpt-4o' in the evaluation system. 
- **Bug Fixes**
	- Ensured that existing functionality and error handling remain intact despite the model change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->