### PR TITLE
Allow disabling github comment

### DIFF
--- a/src/testing/api.ts
+++ b/src/testing/api.ts
@@ -7,6 +7,7 @@ import {
   isCLIRunning,
   isCI,
   ThirdPartyEnvVar,
+  isGitHubCommentDisabled,
 } from '../util';
 import { Evaluation, HumanReviewField } from './models';
 import { determineIfEvaluationPassed, isPrimitive } from './util';
@@ -419,7 +420,13 @@ export async function sendGitHubComment() {
   const githubToken = readEnv(ThirdPartyEnvVar.GITHUB_TOKEN);
   const buildId = readEnv(AutoblocksEnvVar.AUTOBLOCKS_CI_TEST_RUN_BUILD_ID);
 
-  if (!githubToken || !buildId || !isCI() || isCLIRunning()) {
+  if (
+    !githubToken ||
+    !buildId ||
+    !isCI() ||
+    isCLIRunning() ||
+    isGitHubCommentDisabled()
+  ) {
     return;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -16,6 +16,7 @@ export enum AutoblocksEnvVar {
   AUTOBLOCKS_CI_TEST_RUN_BUILD_ID = 'AUTOBLOCKS_CI_TEST_RUN_BUILD_ID',
   AUTOBLOCKS_SLACK_WEBHOOK_URL = 'AUTOBLOCKS_SLACK_WEBHOOK_URL',
   AUTOBLOCKS_TEST_RUN_MESSAGE = 'AUTOBLOCKS_TEST_RUN_MESSAGE',
+  AUTOBLOCKS_DISABLE_GITHUB_COMMENT = 'AUTOBLOCKS_DISABLE_GITHUB_COMMENT',
 }
 
 export enum ThirdPartyEnvVar {
@@ -61,4 +62,8 @@ export function isCI(): boolean {
 
 export function isCLIRunning(): boolean {
   return readEnv(AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS) !== undefined;
+}
+
+export function isGitHubCommentDisabled(): boolean {
+  return readEnv(AutoblocksEnvVar.AUTOBLOCKS_DISABLE_GITHUB_COMMENT) === '1';
 }


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added functionality to disable GitHub comment creation through a new environment variable, providing more control over test output behavior.

- Added `AUTOBLOCKS_DISABLE_GITHUB_COMMENT` to `src/util.ts` AutoblocksEnvVar enum for configuration
- Added `isGitHubCommentDisabled()` helper in `src/util.ts` to check if comments are disabled
- Integrated comment disable check in `src/testing/api.ts` sendGitHubComment function



<!-- /greptile_comment -->