### PR TITLE
Update sdk for pairwise jobs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -167,17 +167,6 @@ interface TestResultWithEvaluations<T = unknown, U = unknown> {
   }[];
 }
 
-interface TestResult<T = unknown, U = unknown> {
-  id: string;
-  runId: string;
-  hash: string;
-  datasetItemId?: string;
-  durationMs?: number;
-  events?: Event[];
-  body: T;
-  output: U;
-}
-
 export class AutoblocksAPIClient {
   private readonly apiKey: string;
   private readonly timeoutMs: number;
@@ -355,10 +344,41 @@ export class AutoblocksAPIClient {
     pairId: string;
   }): Promise<{
     pair: {
-      id: string;
-      hash: string;
-      chosenOutputId?: string;
-      testCaseResults: TestResult[];
+      pairId: string;
+      chosenId?: string;
+      testCases: {
+        id: string;
+        inputFields: {
+          id: string;
+          name: string;
+          value: string;
+          contentType: HumanReviewFieldContentType;
+        }[];
+        outputFields: {
+          id: string;
+          name: string;
+          value: string;
+          contentType: HumanReviewFieldContentType;
+        }[];
+        fieldComments: {
+          fieldId: string;
+          startIdx?: number;
+          endIdx?: number;
+          value: string;
+          inRelationToGradeName?: string;
+          inRelationToAutomatedEvaluationId?: string;
+        }[];
+        inputComments: {
+          value: string;
+          inRelationToGradeName?: string;
+          inRelationToAutomatedEvaluationId?: string;
+        }[];
+        outputComments: {
+          value: string;
+          inRelationToGradeName?: string;
+          inRelationToAutomatedEvaluationId?: string;
+        }[];
+      }[];
     };
   }> {
     return this.get(

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -445,27 +445,48 @@ describe('Autoblocks Client', () => {
           json: () =>
             Promise.resolve({
               pair: {
-                id: 'pair-1',
-                hash: 'hash123',
-                chosenOutputId: 'output-1',
-                testCaseResults: [
+                pairId: 'pair-1',
+                chosenId: 'chosen-1',
+                testCases: [
                   {
-                    id: 'result-1',
-                    runId: 'run-1',
-                    hash: 'hash456',
-                    datasetItemId: 'dataset-1',
-                    durationMs: 1000,
-                    events: [{ id: 'event-1', message: 'Test event' }],
-                    body: { input: 'test input' },
-                    output: { result: 'test output' },
-                  },
-                  {
-                    id: 'result-2',
-                    runId: 'run-2',
-                    hash: 'hash789',
-                    events: [{ id: 'event-2', message: 'Another test event' }],
-                    body: { input: 'another test input' },
-                    output: { result: 'another test output' },
+                    id: 'test-case-1',
+                    inputFields: [
+                      {
+                        id: 'input-1',
+                        name: 'input name',
+                        value: 'input value',
+                        contentType: 'text',
+                      },
+                    ],
+                    outputFields: [
+                      {
+                        id: 'output-1',
+                        name: 'output name',
+                        value: 'output value',
+                        contentType: 'text',
+                      },
+                    ],
+                    fieldComments: [
+                      {
+                        fieldId: 'field-1',
+                        startIdx: 0,
+                        endIdx: 5,
+                        value: 'comment',
+                        inRelationToGradeName: 'grade-1',
+                      },
+                    ],
+                    inputComments: [
+                      {
+                        value: 'input comment',
+                        inRelationToGradeName: 'grade-1',
+                      },
+                    ],
+                    outputComments: [
+                      {
+                        value: 'output comment',
+                        inRelationToAutomatedEvaluationId: 'eval-1',
+                      },
+                    ],
                   },
                 ],
               },
@@ -478,27 +499,48 @@ describe('Autoblocks Client', () => {
       });
 
       expect(result.pair).toEqual({
-        id: 'pair-1',
-        hash: 'hash123',
-        chosenOutputId: 'output-1',
-        testCaseResults: [
+        pairId: 'pair-1',
+        chosenId: 'chosen-1',
+        testCases: [
           {
-            id: 'result-1',
-            runId: 'run-1',
-            hash: 'hash456',
-            datasetItemId: 'dataset-1',
-            durationMs: 1000,
-            events: expect.arrayContaining([expect.any(Object)]),
-            body: { input: 'test input' },
-            output: { result: 'test output' },
-          },
-          {
-            id: 'result-2',
-            runId: 'run-2',
-            hash: 'hash789',
-            events: expect.arrayContaining([expect.any(Object)]),
-            body: { input: 'another test input' },
-            output: { result: 'another test output' },
+            id: 'test-case-1',
+            inputFields: [
+              {
+                id: 'input-1',
+                name: 'input name',
+                value: 'input value',
+                contentType: 'text',
+              },
+            ],
+            outputFields: [
+              {
+                id: 'output-1',
+                name: 'output name',
+                value: 'output value',
+                contentType: 'text',
+              },
+            ],
+            fieldComments: [
+              {
+                fieldId: 'field-1',
+                startIdx: 0,
+                endIdx: 5,
+                value: 'comment',
+                inRelationToGradeName: 'grade-1',
+              },
+            ],
+            inputComments: [
+              {
+                value: 'input comment',
+                inRelationToGradeName: 'grade-1',
+              },
+            ],
+            outputComments: [
+              {
+                value: 'output comment',
+                inRelationToAutomatedEvaluationId: 'eval-1',
+              },
+            ],
           },
         ],
       });


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates the JavaScript SDK to support pairwise human review jobs by restructuring the API response types and removing redundant interfaces.

- Removed redundant `TestResult` interface in favor of `TestResultWithEvaluations` in `/src/client.ts`
- Modified `getHumanReviewJobPair` return type to include input/output fields, comments, and content types
- Renamed fields to match API updates (e.g., `id` to `pairId`, `chosenOutputId` to `chosenId`)
- Updated test cases in `/test/client.spec.ts` to reflect new pairwise job structure
- Added support for field-level comments with relation to grades and automated evaluations



<!-- /greptile_comment -->