### PR TITLE
Add revisionId

### DIFF
--- a/src/datasets-cli/types.ts
+++ b/src/datasets-cli/types.ts
@@ -12,6 +12,7 @@ export enum PropertyTypesEnum {
 
 const zCommonFields = z.object({
   id: z.string().cuid2(),
+  revisionId: z.string().cuid2(),
   name: z.string().min(1),
   required: z.boolean().default(false),
 });

--- a/test/datasets-cli/index.spec.ts
+++ b/test/datasets-cli/index.spec.ts
@@ -16,24 +16,28 @@ describe('Datasets CLI', () => {
               schema: [
                 {
                   id: '1',
+                  revisionId: '1',
                   name: 'name',
                   type: PropertyTypesEnum.String,
                   required: true,
                 },
                 {
                   id: '2',
+                  revisionId: '2',
                   name: 'age',
                   type: PropertyTypesEnum.Number,
                   required: false,
                 },
                 {
                   id: '3',
+                  revisionId: '3',
                   name: 'transcript',
                   type: PropertyTypesEnum.ValidJSON,
                   required: true,
                 },
                 {
                   id: '4',
+                  revisionId: '4',
                   name: 'speciality',
                   type: PropertyTypesEnum.Select,
                   options: ['option1', 'option2', 'option3'],
@@ -51,6 +55,7 @@ describe('Datasets CLI', () => {
               schema: [
                 {
                   id: '1',
+                  revisionId: '1',
                   name: 'isActive',
                   type: PropertyTypesEnum.Boolean,
                   required: true,
@@ -62,12 +67,14 @@ describe('Datasets CLI', () => {
               schema: [
                 {
                   id: '1',
+                  revisionId: '1',
                   name: 'isActive',
                   type: PropertyTypesEnum.Boolean,
                   required: true,
                 },
                 {
                   id: '2',
+                  revisionId: '2',
                   name: 'tags',
                   type: PropertyTypesEnum.MultiSelect,
                   required: false,
@@ -85,6 +92,7 @@ describe('Datasets CLI', () => {
               schema: [
                 {
                   id: '1',
+                  revisionId: '1',
                   name: 'strings',
                   type: PropertyTypesEnum.ListOfStrings,
                   required: false,


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Adds a required `revisionId` field to the dataset schema validation, requiring CUID2 format for both `id` and `revisionId` fields in the `zCommonFields` schema.

- Test data in `/test/datasets-cli/index.spec.ts` uses invalid sequential strings ('1', '2') for `revisionId` that don't match required CUID2 format
- Consider adding uniqueness validation for `revisionId` similar to existing `propertyIdsAreUnique` check in `/src/datasets-cli/types.ts`



<!-- /greptile_comment -->