### PR TITLE
Add ability to send human review job

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -12,6 +12,7 @@ export {
   type EvaluationOverrideField,
   type ScoreChoice,
   type HumanReviewField,
+  type CreateHumanReviewJob,
 } from './models';
 export { HumanReviewFieldContentType } from '../types';
 export { RunManager } from './run-manager';

--- a/src/testing/models.ts
+++ b/src/testing/models.ts
@@ -128,3 +128,8 @@ export interface EvaluationOverride {
   outputFields: EvaluationOverrideField[];
   comments: EvaluationOverrideComment[];
 }
+
+export interface CreateHumanReviewJob {
+  name: string;
+  assigneeEmailAddress: string;
+}

--- a/test/testing/run.spec.ts
+++ b/test/testing/run.spec.ts
@@ -891,6 +891,73 @@ describe('Testing SDK', () => {
     });
   });
 
+  it('creates a human review job', async () => {
+    await runTestSuite<MyTestCase, string>({
+      id: 'my-test-id',
+      testCases: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+      testCaseHash: ['x', 'y'],
+      evaluators: [],
+      fn: async ({ testCase }: { testCase: MyTestCase }) => {
+        return new Promise<string>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              `${testCase.x} + ${testCase.y} = ${testCase.x + testCase.y}`,
+            );
+          }, 100);
+        });
+      },
+      humanReviewJob: {
+        name: 'my-human-review-job',
+        assigneeEmailAddress: 'test@test.com',
+      },
+    });
+
+    expectNumPosts(5);
+    expectPostRequest({
+      path: '/start',
+      body: {
+        testExternalId: 'my-test-id',
+      },
+    });
+    expectPostRequest({
+      path: '/results',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+        testCaseHash: md5(`12`),
+        testCaseBody: { x: 1, y: 2 },
+        testCaseOutput: '1 + 2 = 3',
+      },
+    });
+    expectPostRequest({
+      path: '/results',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+        testCaseHash: md5(`34`),
+        testCaseBody: { x: 3, y: 4 },
+        testCaseOutput: '3 + 4 = 7',
+      },
+    });
+    expectPostRequest({
+      path: '/end',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+      },
+    });
+    expectPublicAPIPostRequest({
+      path: `/runs/${mockRunId}/human-review-job`,
+      body: {
+        name: 'my-human-review-job',
+        assigneeEmailAddress: 'test@test.com',
+      },
+    });
+  });
+
   it('allows specifying a custom hash function', async () => {
     await runTestSuite<MyTestCase, string>({
       id: 'my-test-id',


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Added functionality to create human review jobs in the JavaScript SDK, including a new interface for job creation and integration with test suite execution.

- Added `CreateHumanReviewJob` interface in `/src/testing/models.ts` with required `name` and `assigneeEmailAddress` fields
- Added `humanReviewJob` parameter to `runTestSuite` and `runTestSuiteForGridCombo` functions in `/src/testing/run.ts`
- Added error handling for human review job creation that logs warnings without failing test runs
- Added comprehensive test coverage in `/test/testing/run.spec.ts` verifying job creation and API interactions



<!-- /greptile_comment -->