### PR TITLE
Add support for multiple assignees

### DIFF
--- a/src/testing/models.ts
+++ b/src/testing/models.ts
@@ -131,5 +131,5 @@ export interface EvaluationOverride {
 
 export interface CreateHumanReviewJob {
   name: string;
-  assigneeEmailAddress: string;
+  assigneeEmailAddress: string | string[];
 }

--- a/test/testing/run.spec.ts
+++ b/test/testing/run.spec.ts
@@ -958,6 +958,80 @@ describe('Testing SDK', () => {
     });
   });
 
+  it('creates a human review jobs', async () => {
+    await runTestSuite<MyTestCase, string>({
+      id: 'my-test-id',
+      testCases: [
+        { x: 1, y: 2 },
+        { x: 3, y: 4 },
+      ],
+      testCaseHash: ['x', 'y'],
+      evaluators: [],
+      fn: async ({ testCase }: { testCase: MyTestCase }) => {
+        return new Promise<string>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              `${testCase.x} + ${testCase.y} = ${testCase.x + testCase.y}`,
+            );
+          }, 100);
+        });
+      },
+      humanReviewJob: {
+        name: 'my-human-review-job',
+        assigneeEmailAddress: ['test@test.com', 'test2@test.com'],
+      },
+    });
+
+    expectNumPosts(5);
+    expectPostRequest({
+      path: '/start',
+      body: {
+        testExternalId: 'my-test-id',
+      },
+    });
+    expectPostRequest({
+      path: '/results',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+        testCaseHash: md5(`12`),
+        testCaseBody: { x: 1, y: 2 },
+        testCaseOutput: '1 + 2 = 3',
+      },
+    });
+    expectPostRequest({
+      path: '/results',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+        testCaseHash: md5(`34`),
+        testCaseBody: { x: 3, y: 4 },
+        testCaseOutput: '3 + 4 = 7',
+      },
+    });
+    expectPostRequest({
+      path: '/end',
+      body: {
+        testExternalId: 'my-test-id',
+        runId: mockRunId,
+      },
+    });
+    expectPublicAPIPostRequest({
+      path: `/runs/${mockRunId}/human-review-job`,
+      body: {
+        name: 'my-human-review-job',
+        assigneeEmailAddress: 'test@test.com',
+      },
+    });
+    expectPublicAPIPostRequest({
+      path: `/runs/${mockRunId}/human-review-job`,
+      body: {
+        name: 'my-human-review-job',
+        assigneeEmailAddress: 'test2@test.com',
+      },
+    });
+  });
+
   it('allows specifying a custom hash function', async () => {
     await runTestSuite<MyTestCase, string>({
       id: 'my-test-id',

--- a/test/testing/run.spec.ts
+++ b/test/testing/run.spec.ts
@@ -982,7 +982,7 @@ describe('Testing SDK', () => {
       },
     });
 
-    expectNumPosts(5);
+    expectNumPosts(6);
     expectPostRequest({
       path: '/start',
       body: {


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR adds support for multiple assignees in human review job creation. It updates the type definitions, logic, and test cases to handle an array of email addresses.

• Modified /src/testing/models.ts: Changed assigneeEmailAddress type to string | string[].  
• Updated /src/testing/run.ts: Wrapped single emails into an array and used Promise.allSettled for API calls.  
• Adapted /test/testing/run.spec.ts: Verified that separate API calls are made for each email address.



<!-- /greptile_comment -->