### PR TITLE
EPD-1978: reads AUTOBLOCKS_OVERRIDES

### DIFF
--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -37,6 +37,7 @@ const configRevisionsMap = (): Record<string, string> => {
   const configRevisionsRaw = readEnv(
     AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_CONFIG_REVISIONS,
   );
+
   if (!configRevisionsRaw) {
     return {};
   }

--- a/src/datasets-v2/index.ts
+++ b/src/datasets-v2/index.ts
@@ -10,3 +10,6 @@ export {
   validateConversation,
   type ValidatedConversation,
 } from './validation';
+
+// Export utilities
+export { getSelectedDatasets } from './util';

--- a/src/datasets-v2/util.ts
+++ b/src/datasets-v2/util.ts
@@ -1,0 +1,10 @@
+import { parseAutoblocksOverrides } from '../util';
+
+/**
+ * Gets the list of selected dataset external IDs from overrides.
+ * Returns empty array if no datasets are selected or not in testing context.
+ */
+export const getSelectedDatasets = (): string[] => {
+  const overrides = parseAutoblocksOverrides();
+  return overrides.testSelectedDatasets || [];
+};

--- a/src/prompts/manager-v2.ts
+++ b/src/prompts/manager-v2.ts
@@ -27,6 +27,7 @@ import {
   AUTOBLOCKS_HEADERS,
   REVISION_UNDEPLOYED_VERSION,
   V2_API_ENDPOINT,
+  parseAutoblocksOverrides,
 } from '../util';
 import { renderTemplateWithParams, renderToolWithParams } from './util';
 import { testCaseRunAsyncLocalStorage } from '../asyncLocalStorage';
@@ -64,6 +65,14 @@ const promptRevisionsMap = (): Record<string, string> => {
     return {};
   }
 
+  // Try new unified format first
+  const overrides = parseAutoblocksOverrides();
+
+  if (overrides.promptRevisions) {
+    return overrides.promptRevisions;
+  }
+
+  // Fallback to legacy format
   const promptRevisionsRaw = readEnv(
     AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS,
   );

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -23,6 +23,7 @@ import {
   AUTOBLOCKS_HEADERS,
   API_ENDPOINT,
   REVISION_UNDEPLOYED_VERSION,
+  parseAutoblocksOverrides,
 } from '../util';
 import { renderTemplateWithParams, renderToolWithParams } from './util';
 import { testCaseRunAsyncLocalStorage } from '../asyncLocalStorage';
@@ -48,6 +49,14 @@ const promptRevisionsMap = (): Record<string, string> => {
     return {};
   }
 
+  // Try new unified format first
+  const overrides = parseAutoblocksOverrides();
+
+  if (overrides.promptRevisions) {
+    return overrides.promptRevisions;
+  }
+
+  // Fallback to legacy format
   const promptRevisionsRaw = readEnv(
     AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS,
   );

--- a/src/testing/run-manager.ts
+++ b/src/testing/run-manager.ts
@@ -1,5 +1,5 @@
 import { testCaseRunAsyncLocalStorage } from '../asyncLocalStorage';
-import { AutoblocksEnvVar, readEnv } from '../util';
+import { AutoblocksEnvVar, readEnv, parseAutoblocksOverrides } from '../util';
 import {
   sendEndRun,
   sendEvaluation,
@@ -59,8 +59,7 @@ export class RunManager<
   public async start() {
     const runId = await sendStartRun({
       testExternalId: this.testExternalId,
-      message:
-        this.message || readEnv(AutoblocksEnvVar.AUTOBLOCKS_TEST_RUN_MESSAGE),
+      message: this.message || getTestRunMessage(),
     });
     this.runId = runId;
   }
@@ -196,4 +195,20 @@ export class RunManager<
     });
     this.ended = true;
   }
+}
+
+/**
+ * Gets the test run message from overrides, checking unified format first,
+ * then falling back to legacy format.
+ */
+function getTestRunMessage(): string | undefined {
+  // Try new unified format first
+  const overrides = parseAutoblocksOverrides();
+
+  if (overrides.testRunMessage) {
+    return overrides.testRunMessage;
+  }
+
+  // Fallback to legacy format
+  return readEnv(AutoblocksEnvVar.AUTOBLOCKS_TEST_RUN_MESSAGE);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,6 +12,7 @@ export enum AutoblocksEnvVar {
   AUTOBLOCKS_TRACER_THROW_ON_ERROR = 'AUTOBLOCKS_TRACER_THROW_ON_ERROR',
   AUTOBLOCKS_CLI_SERVER_ADDRESS = 'AUTOBLOCKS_CLI_SERVER_ADDRESS',
   AUTOBLOCKS_FILTERS_TEST_SUITES = 'AUTOBLOCKS_FILTERS_TEST_SUITES',
+  AUTOBLOCKS_OVERRIDES = 'AUTOBLOCKS_OVERRIDES',
   AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS = 'AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS',
   AUTOBLOCKS_OVERRIDES_CONFIG_REVISIONS = 'AUTOBLOCKS_OVERRIDES_CONFIG_REVISIONS',
   AUTOBLOCKS_OVERRIDES_TESTS_AND_HASHES = 'AUTOBLOCKS_OVERRIDES_TESTS_AND_HASHES',
@@ -148,3 +149,24 @@ export function determineStartAndEndIdx(args: {
     `Couldn't find ${symbolAppearanceBeforeAutogeneration} or ${args.symbolType} ${args.symbolName} in ${args.content}`,
   );
 }
+
+export interface AutoblocksOverrides {
+  promptRevisions?: Record<string, string>;
+  testRunMessage?: string;
+  testSelectedDatasets?: string[];
+}
+
+export const parseAutoblocksOverrides = (): AutoblocksOverrides => {
+  const overrides = readEnv(AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES);
+
+  if (!overrides) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(overrides);
+  } catch (err) {
+    console.warn(`Failed to parse AUTOBLOCKS_OVERRIDES: ${err}`);
+    return {};
+  }
+};

--- a/test/datasets-v2/util.spec.ts
+++ b/test/datasets-v2/util.spec.ts
@@ -9,15 +9,6 @@ describe('Datasets V2 Utilities', () => {
   });
 
   describe('getSelectedDatasets', () => {
-    it('returns empty array when not in testing context', () => {
-      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
-        testSelectedDatasets: ['dataset-1', 'dataset-2'],
-      });
-
-      const result = getSelectedDatasets();
-      expect(result).toEqual([]);
-    });
-
     it('returns empty array when no overrides are set', () => {
       process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
         'http://localhost:3000';

--- a/test/datasets-v2/util.spec.ts
+++ b/test/datasets-v2/util.spec.ts
@@ -1,0 +1,76 @@
+import { AutoblocksEnvVar } from '../../src/util';
+import { getSelectedDatasets } from '../../src/datasets-v2/util';
+
+describe('Datasets V2 Utilities', () => {
+  beforeEach(() => {
+    // Clean up environment variables
+    delete process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS];
+    delete process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES];
+  });
+
+  describe('getSelectedDatasets', () => {
+    it('returns empty array when not in testing context', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        testSelectedDatasets: ['dataset-1', 'dataset-2'],
+      });
+
+      const result = getSelectedDatasets();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when no overrides are set', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+
+      const result = getSelectedDatasets();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when testSelectedDatasets is not set in overrides', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        testRunMessage: 'Some message',
+      });
+
+      const result = getSelectedDatasets();
+      expect(result).toEqual([]);
+    });
+
+    it('returns selected datasets when set in overrides', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        testSelectedDatasets: ['dataset-1', 'dataset-2', 'dataset-3'],
+      });
+
+      const result = getSelectedDatasets();
+      expect(result).toEqual(['dataset-1', 'dataset-2', 'dataset-3']);
+    });
+
+    it('returns empty array when testSelectedDatasets is empty', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        testSelectedDatasets: [],
+      });
+
+      const result = getSelectedDatasets();
+      expect(result).toEqual([]);
+    });
+
+    it('handles invalid JSON gracefully', () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = 'invalid json';
+
+      // Should not throw and return empty array
+      const result = getSelectedDatasets();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/test/prompts/manager-v2.spec.ts
+++ b/test/prompts/manager-v2.spec.ts
@@ -493,7 +493,7 @@ describe('Prompt Manager V2', () => {
         ],
       };
 
-      mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+      mockFetch.mockResolvedValueOnce({
         status: 200,
         ok: true,
         json: () => Promise.resolve(mockRevision),

--- a/test/prompts/manager-v2.spec.ts
+++ b/test/prompts/manager-v2.spec.ts
@@ -1,7 +1,22 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { AutoblocksEnvVar, RevisionSpecialVersionsEnum } from '../../src/util';
+import {
+  AutoblocksEnvVar,
+  RevisionSpecialVersionsEnum,
+  V2_API_ENDPOINT,
+} from '../../src/util';
 import { AutoblocksPromptManagerV2 } from '../../src/prompts';
+
+// Mock fs to provide app mapping for test-app
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readFileSync: jest.fn((path, encoding) => {
+    if (path.includes('app-mapping.json')) {
+      return JSON.stringify({ 'test-app': 'test-app-id' });
+    }
+    return jest.requireActual('fs').readFileSync(path, encoding);
+  }),
+}));
 
 describe('Prompt Manager V2', () => {
   let mockFetch;
@@ -507,7 +522,7 @@ describe('Prompt Manager V2', () => {
         ).toEqual('Hello from unified v2, world!');
       });
 
-      expectNumRequests(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith(
         `${V2_API_ENDPOINT}/apps/test-app-id/prompts/my-prompt-id/revisions/unified-revision-id/validate`,
         {

--- a/test/prompts/manager-v2.spec.ts
+++ b/test/prompts/manager-v2.spec.ts
@@ -12,10 +12,12 @@ describe('Prompt Manager V2', () => {
   });
 
   afterEach(() => {
-    delete process.env.AUTOBLOCKS_V2_API_KEY;
+    if (mockFetch) {
+      mockFetch.mockRestore();
+    }
     delete process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS];
+    delete process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES];
     delete process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS];
-    mockFetch.mockRestore();
   });
 
   it('should construct with appName, id, and version', () => {
@@ -447,6 +449,79 @@ describe('Prompt Manager V2', () => {
 
       await expect(manager.init()).rejects.toThrow(
         /Prompt revision overrides are not yet supported for prompt managers using 'dangerously-use-undeployed'/,
+      );
+    });
+
+    it('uses unified AUTOBLOCKS_OVERRIDES format and takes precedence over legacy format', async () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+      // Set both new and legacy formats - new should take precedence
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        promptRevisions: {
+          'my-prompt-id': 'unified-revision-id',
+        },
+      });
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS] =
+        JSON.stringify({
+          'my-prompt-id': 'legacy-revision-id',
+        });
+
+      const mockRevision = {
+        id: 'my-prompt-id',
+        revisionId: 'unified-revision-id',
+        version: 'revision:unified-revision-id',
+        templates: [
+          {
+            id: 'my-template-id',
+            template: 'Hello from unified v2, {{ name }}!',
+          },
+        ],
+      };
+
+      mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve(mockRevision),
+      });
+
+      const mgr = new AutoblocksPromptManagerV2({
+        appName: 'test-app',
+        id: 'my-prompt-id',
+        version: {
+          major: '1',
+          minor: '0',
+        },
+        apiKey: 'mock-api-key',
+      });
+
+      await mgr.init();
+
+      mgr.exec(({ prompt }) => {
+        expect(
+          prompt.renderTemplate({
+            template: 'my-template-id',
+            params: {
+              name: 'world',
+            },
+          }),
+        ).toEqual('Hello from unified v2, world!');
+      });
+
+      expectNumRequests(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${V2_API_ENDPOINT}/apps/test-app-id/prompts/my-prompt-id/revisions/unified-revision-id/validate`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            majorVersion: 1,
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer mock-api-key',
+            'X-Autoblocks-SDK': 'javascript-0.0.0-automated',
+          },
+          signal: AbortSignal.timeout(5_000),
+        },
       );
     });
   });

--- a/test/prompts/manager.spec.ts
+++ b/test/prompts/manager.spec.ts
@@ -16,8 +16,14 @@ describe('Prompt Manager', () => {
     };
 
     afterEach(() => {
+      if (mockFetch) {
+        mockFetch.mockRestore();
+      }
       delete process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS];
-      delete process.env[AutoblocksEnvVar.AUTOBLOCKS_PROMPT_REVISIONS];
+      delete process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES];
+      delete process.env[
+        AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS
+      ];
     });
 
     it('overrides with the prompt revisions when the minor version is hardcoded', async () => {
@@ -71,6 +77,78 @@ describe('Prompt Manager', () => {
       expectNumRequests(1);
       expect(mockFetch).toHaveBeenCalledWith(
         `${API_ENDPOINT}/prompts/my-prompt-id/revisions/my-revision-id/validate`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            majorVersion: 1,
+          }),
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer mock-api-key',
+            'X-Autoblocks-SDK': 'javascript-0.0.0-automated',
+          },
+          signal: AbortSignal.timeout(5_000),
+        },
+      );
+    });
+
+    it('uses unified AUTOBLOCKS_OVERRIDES format and takes precedence over legacy format', async () => {
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_CLI_SERVER_ADDRESS] =
+        'http://localhost:3000';
+      // Set both new and legacy formats - new should take precedence
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES] = JSON.stringify({
+        promptRevisions: {
+          'my-prompt-id': 'unified-revision-id',
+        },
+      });
+      process.env[AutoblocksEnvVar.AUTOBLOCKS_OVERRIDES_PROMPT_REVISIONS] =
+        JSON.stringify({
+          'my-prompt-id': 'legacy-revision-id',
+        });
+
+      const mockRevision = {
+        id: 'my-prompt-id',
+        revisionId: 'unified-revision-id',
+        version: 'revision:unified-revision-id',
+        templates: [
+          {
+            id: 'my-template-id',
+            template: 'Hello from unified, {{ name }}!',
+          },
+        ],
+      };
+
+      mockFetch = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve(mockRevision),
+      });
+
+      const mgr = new AutoblocksPromptManager({
+        id: 'my-prompt-id',
+        version: {
+          major: '1',
+          minor: '0',
+        },
+        apiKey: 'mock-api-key',
+      });
+
+      await mgr.init();
+
+      mgr.exec(({ prompt }) => {
+        expect(
+          prompt.renderTemplate({
+            template: 'my-template-id',
+            params: {
+              name: 'world',
+            },
+          }),
+        ).toEqual('Hello from unified, world!');
+      });
+
+      expectNumRequests(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${API_ENDPOINT}/prompts/my-prompt-id/revisions/unified-revision-id/validate`,
         {
           method: 'POST',
           body: JSON.stringify({


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Introduces a unified format for environment variable overrides through `AUTOBLOCKS_OVERRIDES` while maintaining backward compatibility with legacy environment variables across the SDK.

- Added `parseAutoblocksOverrides()` in `/src/util.ts` to handle unified override format for prompts, test runs, and datasets
- Added `/src/datasets-v2/util.ts` with `getSelectedDatasets()` function to retrieve dataset IDs from overrides
- Modified prompt managers in `/src/prompts/manager.ts` and `/src/prompts/manager-v2.ts` to check unified format before legacy format
- Updated test files with comprehensive coverage for both unified and legacy override formats, including proper cleanup



<!-- /greptile_comment -->