### PR TITLE
EPD-1997: update endpoints and add split filter

### DIFF
--- a/e2e/test-datasets-v2-ts/test/items.spec.ts
+++ b/e2e/test-datasets-v2-ts/test/items.spec.ts
@@ -58,6 +58,14 @@ describe('Dataset Items Operations', () => {
     testItemId = items[0].id;
   });
 
+  it('should retrieve items from the dataset with split filter', async () => {
+    const trainItems = await client.datasets.getItems(testDatasetId, ['train']);
+
+    expect(trainItems.length).toBe(2);
+    expect(trainItems[0].splits).toContain('train');
+    expect(trainItems[1].splits).toContain('train');
+  });
+
   it('should retrieve items by revision ID', async () => {
     const itemsByRevision = await client.datasets.getItemsByRevision({
       externalId: testDatasetId,

--- a/src/datasets-v2/client.ts
+++ b/src/datasets-v2/client.ts
@@ -51,9 +51,13 @@ export class DatasetsV2Client extends BaseAppResourceClient {
   /**
    * Get all items for a dataset
    */
-  async getItems(externalId: string): Promise<DatasetItemV2[]> {
+  async getItems(
+    externalId: string,
+    splits?: string[],
+  ): Promise<DatasetItemV2[]> {
+    const queryString = splits?.length ? `?splits=${splits.join(',')}` : '';
     return this.get<DatasetItemV2[]>(
-      `/apps/${this.appSlug}/datasets/${externalId}/items`,
+      `/apps/${this.appSlug}/datasets/${externalId}/items${queryString}`,
     );
   }
 
@@ -78,7 +82,7 @@ export class DatasetsV2Client extends BaseAppResourceClient {
     schemaVersion: number;
   }): Promise<DatasetSchemaV2> {
     return this.get<DatasetSchemaV2>(
-      `/apps/${this.appSlug}/datasets/${params.externalId}/schema-versions/${params.schemaVersion}`,
+      `/apps/${this.appSlug}/datasets/${params.externalId}/schema/${params.schemaVersion}`,
     );
   }
 
@@ -110,7 +114,7 @@ export class DatasetsV2Client extends BaseAppResourceClient {
       ? `?splits=${params.splits.join(',')}`
       : '';
     return this.get<DatasetItemV2[]>(
-      `/apps/${this.appSlug}/datasets/${params.externalId}/schema-versions/${params.schemaVersion}/items${queryString}`,
+      `/apps/${this.appSlug}/datasets/${params.externalId}/schema/${params.schemaVersion}/items${queryString}`,
     );
   }
 

--- a/test/api/app-client.spec.ts
+++ b/test/api/app-client.spec.ts
@@ -160,9 +160,7 @@ describe('AutoblocksAppClient (v2)', () => {
       });
       expect(schema.schemaVersion).toBe(1);
       expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `/apps/${appSlug}/datasets/ds2/schema-versions/1`,
-        ),
+        expect.stringContaining(`/apps/${appSlug}/datasets/ds2/schema/1`),
         expect.objectContaining({
           method: 'GET',
           headers: expect.objectContaining({
@@ -211,7 +209,7 @@ describe('AutoblocksAppClient (v2)', () => {
       expect(items[0].id).toBe('item3');
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining(
-          `/apps/${appSlug}/datasets/ds2/schema-versions/1/items?splits=split1`,
+          `/apps/${appSlug}/datasets/ds2/schema/1/items?splits=split1`,
         ),
         expect.objectContaining({
           method: 'GET',


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Updates the datasets-v2 client to support filtering items by split names and modifies schema-related endpoint paths from 'schema-versions' to 'schema'.

- Added split filtering capability to `getItems` method in `/src/datasets-v2/client.ts`
- Added comprehensive test coverage in `/e2e/test-datasets-v2-ts/test/items.spec.ts` for split filtering functionality
- Updated schema-related endpoint paths from 'schema-versions' to 'schema' for consistency
- Implemented consistent query parameter handling for splits across all relevant methods



<!-- /greptile_comment -->