### PR TITLE
use env variable for api endpoint

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,10 @@
 import type { SymbolType, TimeDelta } from './types';
 import packageJson from '../package.json';
 
-export const INGESTION_ENDPOINT = 'https://ingest-event.autoblocks.ai';
-export const API_ENDPOINT = 'https://api.autoblocks.ai';
-export const V2_API_ENDPOINT = 'https://api-v2.autoblocks.ai';
-
 export enum AutoblocksEnvVar {
   AUTOBLOCKS_API_KEY = 'AUTOBLOCKS_API_KEY',
   AUTOBLOCKS_V2_API_KEY = 'AUTOBLOCKS_V2_API_KEY',
+  AUTOBLOCKS_V2_API_ENDPOINT = 'AUTOBLOCKS_V2_API_ENDPOINT',
   AUTOBLOCKS_INGESTION_KEY = 'AUTOBLOCKS_INGESTION_KEY',
   AUTOBLOCKS_TRACER_THROW_ON_ERROR = 'AUTOBLOCKS_TRACER_THROW_ON_ERROR',
   AUTOBLOCKS_CLI_SERVER_ADDRESS = 'AUTOBLOCKS_CLI_SERVER_ADDRESS',
@@ -21,6 +18,12 @@ export enum AutoblocksEnvVar {
   AUTOBLOCKS_TEST_RUN_MESSAGE = 'AUTOBLOCKS_TEST_RUN_MESSAGE',
   AUTOBLOCKS_DISABLE_GITHUB_COMMENT = 'AUTOBLOCKS_DISABLE_GITHUB_COMMENT',
 }
+
+export const INGESTION_ENDPOINT = 'https://ingest-event.autoblocks.ai';
+export const API_ENDPOINT = 'https://api.autoblocks.ai';
+export const V2_API_ENDPOINT =
+  process.env[AutoblocksEnvVar.AUTOBLOCKS_V2_API_ENDPOINT] ||
+  'https://api-v2.autoblocks.ai';
 
 export enum ThirdPartyEnvVar {
   OPENAI_API_KEY = 'OPENAI_API_KEY',


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

Makes the V2 API endpoint configurable through environment variables, enabling support for self-hosted instances and custom environments in the JavaScript SDK.

- Modified `src/util.ts` to introduce `AUTOBLOCKS_V2_API_ENDPOINT` environment variable for configuring the API endpoint
- Added fallback to default endpoint 'https://api-v2.autoblocks.ai' when environment variable is not set
- Reorganized endpoint constants in `src/util.ts` for better code organization



<!-- /greptile_comment -->