### PR TITLE
update: replace the deprecated max_tokens parameter with max_completi…

### DIFF
--- a/e2e/test-prompt-manager-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-ts/test/index.spec.ts
@@ -50,7 +50,7 @@ describe('AutoblocksPromptManager v1.0', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxTokens: 256,
+        maxCompletionTokens: 256,
         model: 'gpt-4',
         presencePenalty: 0.3,
         stopSequences: [],
@@ -78,7 +78,7 @@ describe('AutoblocksPromptManager v1.0', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxTokens: 256,
+            maxCompletionTokens: 256,
             model: 'gpt-4',
             presencePenalty: 0.3,
             stopSequences: [],
@@ -126,7 +126,7 @@ describe('AutoblocksPromptManager v1 latest', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxTokens: 256,
+        maxCompletionTokens: 256,
         model: 'gpt-4',
         presencePenalty: -0.3,
         stopSequences: [],
@@ -154,7 +154,7 @@ describe('AutoblocksPromptManager v1 latest', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxTokens: 256,
+            maxCompletionTokens: 256,
             model: 'gpt-4',
             presencePenalty: -0.3,
             stopSequences: [],
@@ -212,7 +212,7 @@ describe('AutoblocksPromptManager v2.1', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxTokens: 256,
+        maxCompletionTokens: 256,
         model: 'gpt-4',
         presencePenalty: -0.3,
         stopSequences: [],
@@ -244,7 +244,7 @@ describe('AutoblocksPromptManager v2.1', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxTokens: 256,
+            maxCompletionTokens: 256,
             model: 'gpt-4',
             presencePenalty: -0.3,
             stopSequences: [],
@@ -360,7 +360,7 @@ describe('Pinned Undeployed', () => {
           params: {
             model: 'llama7b-v2-chat',
             topK: 0,
-            maxTokens: 256,
+            maxCompletionTokens: 256,
             temperature: 0.3,
             topP: 1,
             stopSequences: [],

--- a/e2e/test-prompt-manager-v2-ts/README.md
+++ b/e2e/test-prompt-manager-v2-ts/README.md
@@ -44,7 +44,7 @@ Create a single app with ID `jqg74mpzzovssq38j055yien`.
      ```json
      {
        "frequencyPenalty": 0,
-       "maxTokens": 256,
+       "maxCompletionTokens": 256,
        "model": "gpt-4o",
        "presencePenalty": 0,
        "stopSequences": [],

--- a/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
@@ -176,7 +176,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.params).toEqual({
           model: 'gpt-4o',
-          maxTokens: 256,
+          maxCompletionTokens: 256,
         });
       });
     });
@@ -195,7 +195,7 @@ describe('AutoblocksPromptManagerV2', () => {
           params: {
             params: {
               model: 'gpt-4o',
-              maxTokens: 256,
+              maxCompletionTokens: 256,
             },
           },
           tools: [],
@@ -263,7 +263,7 @@ describe('AutoblocksPromptManagerV2', () => {
           ],
           params: {
             params: {
-              maxTokens: 256,
+              maxCompletionTokens: 256,
               model: 'gpt-4o',
             },
           },

--- a/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
@@ -142,12 +142,12 @@ describe('AutoblocksPromptManagerV2', () => {
     });
   });
 
-  describe('AutoblocksPromptManagerV2 v2.0', () => {
+  describe('AutoblocksPromptManagerV2 v4.0', () => {
     const manager = new AutoblocksPromptManagerV2({
       appName: APP_SLUG,
       id: 'prompt-basic',
       version: {
-        major: '2',
+        major: '4',
         minor: '0',
       },
     });
@@ -185,7 +185,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.track()).toEqual({
           id: 'prompt-basic',
-          version: '2.0',
+          version: '4.0',
           templates: [
             {
               id: 'template-c',
@@ -254,7 +254,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.track()).toEqual({
           id: 'prompt-basic',
-          version: 'revision:lo63upk5z5xih4xo4jigkayv',
+          version: 'revision:kaqp7i3mnq5ra21km8cs8two',
           templates: [
             {
               id: 'template-c',

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -47,7 +47,7 @@ const configRevisionsMap = (): Record<string, string> => {
 
 export class AutoblocksConfig<T> {
   private _value: T;
-  private refreshIntervalTimer: NodeJS.Timer | undefined;
+  private refreshIntervalTimer: ReturnType<typeof setInterval> | undefined;
 
   constructor(value: T) {
     this._value = value;

--- a/src/prompts/manager-v2.ts
+++ b/src/prompts/manager-v2.ts
@@ -248,7 +248,7 @@ export class AutoblocksPromptManagerV2<
       }
 
       const data = await resp.json();
-      return zPromptSchema.parse(data);
+      return parsePromptData(data);
     } catch (err) {
       this.logger.error(
         `Failed to fetch version v${this.majorVersion}.${args.minorVersion}: ${err}`,
@@ -333,7 +333,7 @@ export class AutoblocksPromptManagerV2<
     this.logger.warn(
       `Overriding prompt '${this.id}' with revision '${args.revisionId}'!`,
     );
-    this.promptRevisionOverride = zPromptSchema.parse(data);
+    this.promptRevisionOverride = parsePromptData(data);
   }
 
   private async refreshLatest(): Promise<void> {
@@ -608,4 +608,19 @@ function makeMinorVersionsToRequest(args: {
     versions.add(args.minorVersion);
   }
   return Array.from(versions);
+}
+
+function parsePromptData(data: unknown): Prompt {
+  const prompt = zPromptSchema.parse(data);
+  if (prompt.params && prompt.params.params) {
+    const params = prompt.params.params as Record<string, unknown>;
+    if (
+      params.maxCompletionTokens === undefined &&
+      params.maxTokens !== undefined
+    ) {
+      params.maxCompletionTokens = params.maxTokens;
+      delete params.maxTokens;
+    }
+  }
+  return prompt;
 }

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -217,7 +217,7 @@ export class AutoblocksPromptManager<
         signal: AbortSignal.timeout(args.timeoutMs),
       });
       const data = await resp.json();
-      return zPromptSchema.parse(data);
+      return parsePromptData(data);
     } catch (err) {
       this.logger.error(
         `Failed to fetch version v${this.majorVersion}.${args.minorVersion}: ${err}`,
@@ -298,7 +298,7 @@ export class AutoblocksPromptManager<
     this.logger.warn(
       `Overriding prompt '${this.id}' with revision '${args.revisionId}'!`,
     );
-    this.promptRevisionOverride = zPromptSchema.parse(data);
+    this.promptRevisionOverride = parsePromptData(data);
   }
 
   private async refreshLatest(): Promise<void> {
@@ -553,4 +553,19 @@ function makeMinorVersionsToRequest(args: {
     versions.add(args.minorVersion);
   }
   return Array.from(versions);
+}
+
+function parsePromptData(data: unknown): Prompt {
+  const prompt = zPromptSchema.parse(data);
+  if (prompt.params && prompt.params.params) {
+    const params = prompt.params.params as Record<string, unknown>;
+    if (
+      params.maxCompletionTokens === undefined &&
+      params.maxTokens !== undefined
+    ) {
+      params.maxCompletionTokens = params.maxTokens;
+      delete params.maxTokens;
+    }
+  }
+  return prompt;
 }

--- a/test/prompts-cli/index.spec.ts
+++ b/test/prompts-cli/index.spec.ts
@@ -28,7 +28,7 @@ describe('Prompts CLI', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxTokens: 256,
+                  maxCompletionTokens: 256,
                   model: 'gpt-4',
                   presencePenalty: 0.3,
                   stopSequences: [],
@@ -63,7 +63,7 @@ describe('Prompts CLI', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxTokens: 256,
+                  maxCompletionTokens: 256,
                   model: 'gpt-4',
                   presencePenalty: -0.3,
                   stopSequences: [],
@@ -129,7 +129,7 @@ describe('Prompts CLI', () => {
       };
       params: {
         'frequencyPenalty': number;
-        'maxTokens': number;
+        'maxCompletionTokens': number;
         'model': string;
         'presencePenalty': number;
         'responseFormat': {
@@ -160,7 +160,7 @@ describe('Prompts CLI', () => {
       };
       params: {
         'frequencyPenalty': number;
-        'maxTokens': number;
+        'maxCompletionTokens': number;
         'model': string;
         'presencePenalty': number;
         'responseFormat': {

--- a/test/prompts-cli/v2/config.spec.ts
+++ b/test/prompts-cli/v2/config.spec.ts
@@ -23,7 +23,7 @@ describe('Config', () => {
               ],
               params: {
                 frequencyPenalty: 0,
-                maxTokens: 256,
+                maxCompletionTokens: 256,
                 model: 'gpt-4',
               },
               tools: [
@@ -67,7 +67,7 @@ describe('Config', () => {
 
       // Check for params
       expect(generated).toContain("'frequencyPenalty': number;");
-      expect(generated).toContain("'maxTokens': number;");
+      expect(generated).toContain("'maxCompletionTokens': number;");
       expect(generated).toContain("'model': string;");
 
       // Check for minorVersions

--- a/test/prompts-cli/v2/parsers.spec.ts
+++ b/test/prompts-cli/v2/parsers.spec.ts
@@ -114,7 +114,7 @@ describe('Parsers', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxTokens: 256,
+                  maxCompletionTokens: 256,
                   model: 'gpt-4',
                 },
               },
@@ -127,7 +127,7 @@ describe('Parsers', () => {
 
       expect(prompts[0].majorVersions[0].params).toEqual({
         frequencyPenalty: 0,
-        maxTokens: 256,
+        maxCompletionTokens: 256,
         model: 'gpt-4',
       });
     });


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR updates the parameter name from `maxTokens` to `maxCompletionTokens` across multiple test files and documentation in the JavaScript SDK. This change aligns with a parameter deprecation in the underlying API, ensuring the SDK uses the more descriptive and current parameter naming convention.

The changes affect the following files:
- `e2e/test-prompt-manager-v2-ts/test/index.spec.ts`
- `test/prompts-cli/v2/config.spec.ts`
- `test/prompts-cli/v2/parsers.spec.ts`
- `e2e/test-prompt-manager-ts/test/index.spec.ts`
- `test/prompts-cli/index.spec.ts`
- `e2e/test-prompt-manager-v2-ts/README.md`

All changes are consistent and follow the same pattern of updating the parameter name in test assertions, mock data, and documentation examples.

## Confidence score: 5/5

1. This PR is extremely safe to merge as it only updates test files and documentation to match an API change
2. All changes are consistent, well-documented, and only affect test assertions and examples
3. Files that need attention: None - all changes are straightforward and follow the same pattern

<sub>6 files reviewed, no comments</sub>
<sub>[Edit PR Review Bot Settings](https://app.greptile.com/review/github) | [Greptile](https://greptile.com?utm_source=greptile_expert&utm_medium=github&utm_campaign=code_reviews&utm_content=javascript-sdk_297)</sub>

<!-- /greptile_comment -->