### PR TITLE
Add maxTokens back

### DIFF
--- a/e2e/test-prompt-manager-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-ts/test/index.spec.ts
@@ -50,7 +50,7 @@ describe('AutoblocksPromptManager v1.0', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxCompletionTokens: 256,
+        maxTokens: 256,
         model: 'gpt-4',
         presencePenalty: 0.3,
         stopSequences: [],
@@ -78,7 +78,7 @@ describe('AutoblocksPromptManager v1.0', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxCompletionTokens: 256,
+            maxTokens: 256,
             model: 'gpt-4',
             presencePenalty: 0.3,
             stopSequences: [],
@@ -126,7 +126,7 @@ describe('AutoblocksPromptManager v1 latest', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxCompletionTokens: 256,
+        maxTokens: 256,
         model: 'gpt-4',
         presencePenalty: -0.3,
         stopSequences: [],
@@ -154,7 +154,7 @@ describe('AutoblocksPromptManager v1 latest', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxCompletionTokens: 256,
+            maxTokens: 256,
             model: 'gpt-4',
             presencePenalty: -0.3,
             stopSequences: [],
@@ -212,7 +212,7 @@ describe('AutoblocksPromptManager v2.1', () => {
     manager.exec(({ prompt }) => {
       expect(prompt.params).toEqual({
         frequencyPenalty: 0,
-        maxCompletionTokens: 256,
+        maxTokens: 256,
         model: 'gpt-4',
         presencePenalty: -0.3,
         stopSequences: [],
@@ -244,7 +244,7 @@ describe('AutoblocksPromptManager v2.1', () => {
         params: {
           params: {
             frequencyPenalty: 0,
-            maxCompletionTokens: 256,
+            maxTokens: 256,
             model: 'gpt-4',
             presencePenalty: -0.3,
             stopSequences: [],
@@ -360,7 +360,7 @@ describe('Pinned Undeployed', () => {
           params: {
             model: 'llama7b-v2-chat',
             topK: 0,
-            maxCompletionTokens: 256,
+            maxTokens: 256,
             temperature: 0.3,
             topP: 1,
             stopSequences: [],

--- a/e2e/test-prompt-manager-v2-ts/README.md
+++ b/e2e/test-prompt-manager-v2-ts/README.md
@@ -44,7 +44,7 @@ Create a single app with ID `jqg74mpzzovssq38j055yien`.
      ```json
      {
        "frequencyPenalty": 0,
-       "maxCompletionTokens": 256,
+       "maxTokens": 256,
        "model": "gpt-4o",
        "presencePenalty": 0,
        "stopSequences": [],

--- a/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
@@ -142,12 +142,12 @@ describe('AutoblocksPromptManagerV2', () => {
     });
   });
 
-  describe('AutoblocksPromptManagerV2 v4.0', () => {
+  describe('AutoblocksPromptManagerV2 v2.0', () => {
     const manager = new AutoblocksPromptManagerV2({
       appName: APP_SLUG,
       id: 'prompt-basic',
       version: {
-        major: '4',
+        major: '2',
         minor: '0',
       },
     });
@@ -176,7 +176,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.params).toEqual({
           model: 'gpt-4o',
-          maxCompletionTokens: 256,
+          maxTokens: 256,
         });
       });
     });
@@ -185,7 +185,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.track()).toEqual({
           id: 'prompt-basic',
-          version: '4.0',
+          version: '2.0',
           templates: [
             {
               id: 'template-c',
@@ -195,7 +195,7 @@ describe('AutoblocksPromptManagerV2', () => {
           params: {
             params: {
               model: 'gpt-4o',
-              maxCompletionTokens: 256,
+              maxTokens: 256,
             },
           },
           tools: [],
@@ -254,7 +254,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.track()).toEqual({
           id: 'prompt-basic',
-          version: 'revision:kaqp7i3mnq5ra21km8cs8two',
+          version: 'revision:lo63upk5z5xih4xo4jigkayv',
           templates: [
             {
               id: 'template-c',
@@ -263,7 +263,7 @@ describe('AutoblocksPromptManagerV2', () => {
           ],
           params: {
             params: {
-              maxCompletionTokens: 256,
+              maxTokens: 256,
               model: 'gpt-4o',
             },
           },

--- a/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
@@ -254,7 +254,7 @@ describe('AutoblocksPromptManagerV2', () => {
       manager.exec(({ prompt }) => {
         expect(prompt.track()).toEqual({
           id: 'prompt-basic',
-          version: 'revision:lo63upk5z5xih4xo4jigkayv',
+          version: 'revision:kaqp7i3mnq5ra21km8cs8two',
           templates: [
             {
               id: 'template-c',

--- a/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
+++ b/e2e/test-prompt-manager-v2-ts/test/index.spec.ts
@@ -263,7 +263,7 @@ describe('AutoblocksPromptManagerV2', () => {
           ],
           params: {
             params: {
-              maxTokens: 256,
+              maxCompletionTokens: 256,
               model: 'gpt-4o',
             },
           },

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -47,7 +47,7 @@ const configRevisionsMap = (): Record<string, string> => {
 
 export class AutoblocksConfig<T> {
   private _value: T;
-  private refreshIntervalTimer: ReturnType<typeof setInterval> | undefined;
+  private refreshIntervalTimer: NodeJS.Timer | undefined;
 
   constructor(value: T) {
     this._value = value;

--- a/src/prompts/manager-v2.ts
+++ b/src/prompts/manager-v2.ts
@@ -248,7 +248,7 @@ export class AutoblocksPromptManagerV2<
       }
 
       const data = await resp.json();
-      return parsePromptData(data);
+      return zPromptSchema.parse(data);
     } catch (err) {
       this.logger.error(
         `Failed to fetch version v${this.majorVersion}.${args.minorVersion}: ${err}`,
@@ -333,7 +333,7 @@ export class AutoblocksPromptManagerV2<
     this.logger.warn(
       `Overriding prompt '${this.id}' with revision '${args.revisionId}'!`,
     );
-    this.promptRevisionOverride = parsePromptData(data);
+    this.promptRevisionOverride = zPromptSchema.parse(data);
   }
 
   private async refreshLatest(): Promise<void> {
@@ -608,19 +608,4 @@ function makeMinorVersionsToRequest(args: {
     versions.add(args.minorVersion);
   }
   return Array.from(versions);
-}
-
-function parsePromptData(data: unknown): Prompt {
-  const prompt = zPromptSchema.parse(data);
-  if (prompt.params && prompt.params.params) {
-    const params = prompt.params.params as Record<string, unknown>;
-    if (
-      params.maxCompletionTokens === undefined &&
-      params.maxTokens !== undefined
-    ) {
-      params.maxCompletionTokens = params.maxTokens;
-      delete params.maxTokens;
-    }
-  }
-  return prompt;
 }

--- a/src/prompts/manager.ts
+++ b/src/prompts/manager.ts
@@ -217,7 +217,7 @@ export class AutoblocksPromptManager<
         signal: AbortSignal.timeout(args.timeoutMs),
       });
       const data = await resp.json();
-      return parsePromptData(data);
+      return zPromptSchema.parse(data);
     } catch (err) {
       this.logger.error(
         `Failed to fetch version v${this.majorVersion}.${args.minorVersion}: ${err}`,
@@ -298,7 +298,7 @@ export class AutoblocksPromptManager<
     this.logger.warn(
       `Overriding prompt '${this.id}' with revision '${args.revisionId}'!`,
     );
-    this.promptRevisionOverride = parsePromptData(data);
+    this.promptRevisionOverride = zPromptSchema.parse(data);
   }
 
   private async refreshLatest(): Promise<void> {
@@ -553,19 +553,4 @@ function makeMinorVersionsToRequest(args: {
     versions.add(args.minorVersion);
   }
   return Array.from(versions);
-}
-
-function parsePromptData(data: unknown): Prompt {
-  const prompt = zPromptSchema.parse(data);
-  if (prompt.params && prompt.params.params) {
-    const params = prompt.params.params as Record<string, unknown>;
-    if (
-      params.maxCompletionTokens === undefined &&
-      params.maxTokens !== undefined
-    ) {
-      params.maxCompletionTokens = params.maxTokens;
-      delete params.maxTokens;
-    }
-  }
-  return prompt;
 }

--- a/test/prompts-cli/index.spec.ts
+++ b/test/prompts-cli/index.spec.ts
@@ -28,7 +28,7 @@ describe('Prompts CLI', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxCompletionTokens: 256,
+                  maxTokens: 256,
                   model: 'gpt-4',
                   presencePenalty: 0.3,
                   stopSequences: [],
@@ -63,7 +63,7 @@ describe('Prompts CLI', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxCompletionTokens: 256,
+                  maxTokens: 256,
                   model: 'gpt-4',
                   presencePenalty: -0.3,
                   stopSequences: [],
@@ -129,7 +129,7 @@ describe('Prompts CLI', () => {
       };
       params: {
         'frequencyPenalty': number;
-        'maxCompletionTokens': number;
+        'maxTokens': number;
         'model': string;
         'presencePenalty': number;
         'responseFormat': {
@@ -160,7 +160,7 @@ describe('Prompts CLI', () => {
       };
       params: {
         'frequencyPenalty': number;
-        'maxCompletionTokens': number;
+        'maxTokens': number;
         'model': string;
         'presencePenalty': number;
         'responseFormat': {

--- a/test/prompts-cli/v2/config.spec.ts
+++ b/test/prompts-cli/v2/config.spec.ts
@@ -23,7 +23,7 @@ describe('Config', () => {
               ],
               params: {
                 frequencyPenalty: 0,
-                maxCompletionTokens: 256,
+                maxTokens: 256,
                 model: 'gpt-4',
               },
               tools: [
@@ -67,7 +67,7 @@ describe('Config', () => {
 
       // Check for params
       expect(generated).toContain("'frequencyPenalty': number;");
-      expect(generated).toContain("'maxCompletionTokens': number;");
+      expect(generated).toContain("'maxTokens': number;");
       expect(generated).toContain("'model': string;");
 
       // Check for minorVersions

--- a/test/prompts-cli/v2/parsers.spec.ts
+++ b/test/prompts-cli/v2/parsers.spec.ts
@@ -114,7 +114,7 @@ describe('Parsers', () => {
               params: {
                 params: {
                   frequencyPenalty: 0,
-                  maxCompletionTokens: 256,
+                  maxTokens: 256,
                   model: 'gpt-4',
                 },
               },
@@ -127,7 +127,7 @@ describe('Parsers', () => {
 
       expect(prompts[0].majorVersions[0].params).toEqual({
         frequencyPenalty: 0,
-        maxCompletionTokens: 256,
+        maxTokens: 256,
         model: 'gpt-4',
       });
     });


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR reverts parameter naming from `maxCompletionTokens` back to `maxTokens` across the Autoblocks JavaScript SDK. The changes affect multiple components including prompt managers (both v1 and v2), CLI tools, test suites, and documentation.

The core technical changes involve:

1. **Prompt Manager Simplification**: Removes custom `parsePromptData` functions from both `manager.ts` and `manager-v2.ts` that were handling backward compatibility by transforming deprecated `maxTokens` parameters to `maxCompletionTokens`. The code now directly uses `zPromptSchema.parse(data)` without transformation.

2. **Test Suite Updates**: Updates all test files to expect `maxTokens` instead of `maxCompletionTokens` in prompt parameters and tracking information. This includes end-to-end tests, CLI tests, and unit tests.

3. **CLI Type Generation**: Updates the prompts CLI tests to generate TypeScript interfaces with `maxTokens` instead of `maxCompletionTokens`, ensuring generated types match the API contract.

4. **Documentation Alignment**: Updates the V2 prompt manager README to document the correct parameter names for test setup.

The changes maintain consistency with OpenAI's standard parameter naming conventions while simplifying the codebase by removing client-side transformation logic. The responsibility for parameter handling appears to have been moved to the server-side API or the underlying schema validation layer.

## Confidence score: 3/5

- This change introduces potential compatibility issues, particularly with the timer typing change that uses deprecated `NodeJS.Timer`
- The parameter naming reversion may break existing prompts or integrations that expect `maxCompletionTokens`
- Files need attention: `src/configs/config.ts` for the deprecated timer typing, and the prompt manager files to ensure all downstream consumers handle the parameter name change correctly

<!-- /greptile_comment -->