### PR TITLE
feat:Added interfaces, client methods, exports, and tests for human r…

### DIFF
--- a/src/human-review/client.ts
+++ b/src/human-review/client.ts
@@ -3,6 +3,10 @@ import {
   HumanReviewJobListResponse,
   HumanReviewJobDetail,
   HumanReviewJobItemDetail,
+  GetJobTestCasesResponse,
+  GetJobTestCaseResultResponse,
+  GetJobPairsResponse,
+  GetJobPairResponse,
 } from './models';
 
 export class HumanReviewClient extends BaseAppResourceClient {
@@ -33,6 +37,48 @@ export class HumanReviewClient extends BaseAppResourceClient {
   }): Promise<HumanReviewJobItemDetail> {
     return this.get<HumanReviewJobItemDetail>(
       `/apps/${this.appSlug}/human-review/jobs/${args.jobId}/items/${args.itemId}`,
+    );
+  }
+
+  /**
+   * Get all test cases for a job
+   */
+  async getJobTestCases(jobId: string): Promise<GetJobTestCasesResponse> {
+    return this.get<GetJobTestCasesResponse>(
+      `/apps/${this.appSlug}/human-review/jobs/${jobId}/test_cases`,
+    );
+  }
+
+  /**
+   * Get the result for a specific test case
+   */
+  async getJobTestCaseResult(args: {
+    jobId: string;
+    testCaseId: string;
+  }): Promise<GetJobTestCaseResultResponse> {
+    return this.get<GetJobTestCaseResultResponse>(
+      `/apps/${this.appSlug}/human-review/jobs/${args.jobId}/test_cases/${args.testCaseId}/result`,
+    );
+  }
+
+  /**
+   * Get all comparison pairs for a job
+   */
+  async getJobPairs(jobId: string): Promise<GetJobPairsResponse> {
+    return this.get<GetJobPairsResponse>(
+      `/apps/${this.appSlug}/human-review/jobs/${jobId}/pairs`,
+    );
+  }
+
+  /**
+   * Get a specific comparison pair
+   */
+  async getJobPair(args: {
+    jobId: string;
+    pairId: string;
+  }): Promise<GetJobPairResponse> {
+    return this.get<GetJobPairResponse>(
+      `/apps/${this.appSlug}/human-review/jobs/${args.jobId}/pairs/${args.pairId}`,
     );
   }
 }

--- a/src/human-review/models.ts
+++ b/src/human-review/models.ts
@@ -81,3 +81,35 @@ export interface HumanReviewGeneralComment {
   inRelationToScoreName?: string;
   user: HumanReviewUser;
 }
+
+// Job test cases response
+export interface GetJobTestCasesResponse {
+  testCases: {
+    id: string;
+    input: Record<string, string>;
+    output: Record<string, string>;
+  }[];
+}
+
+// Job test case result response
+export interface GetJobTestCaseResultResponse {
+  id: string;
+  result: Record<string, unknown>;
+}
+
+// Job pairs response
+export interface GetJobPairsResponse {
+  pairs: {
+    id: string;
+    leftOutput: string;
+    rightOutput: string;
+  }[];
+}
+
+// Job pair response
+export interface GetJobPairResponse {
+  id: string;
+  leftOutput: string;
+  rightOutput: string;
+  winner?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,4 +53,8 @@ export type {
   HumanReviewJobDetail,
   HumanReviewScore,
   HumanReviewScoreOptions,
+  GetJobTestCasesResponse,
+  GetJobTestCaseResultResponse,
+  GetJobPairsResponse,
+  GetJobPairResponse,
 } from './human-review/models';

--- a/test/api/app-client.spec.ts
+++ b/test/api/app-client.spec.ts
@@ -332,5 +332,107 @@ describe('AutoblocksAppClient (v2)', () => {
         }),
       );
     });
+
+    it('calls humanReview.getJobTestCases()', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            testCases: [{ id: 'tc1', input: { a: 'b' }, output: { c: 'd' } }],
+          }),
+      });
+      const client = new AutoblocksAppClient({ appSlug, apiKey });
+      const result = await client.humanReview.getJobTestCases('job2');
+      expect(result.testCases[0].id).toBe('tc1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/apps/${appSlug}/human-review/jobs/job2/test_cases`,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${apiKey}`,
+          }),
+        }),
+      );
+    });
+
+    it('calls humanReview.getJobTestCaseResult()', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: 'tc1', result: { foo: 'bar' } }),
+      });
+      const client = new AutoblocksAppClient({ appSlug, apiKey });
+      const result = await client.humanReview.getJobTestCaseResult({
+        jobId: 'job2',
+        testCaseId: 'tc1',
+      });
+      expect(result.id).toBe('tc1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/apps/${appSlug}/human-review/jobs/job2/test_cases/tc1/result`,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${apiKey}`,
+          }),
+        }),
+      );
+    });
+
+    it('calls humanReview.getJobPairs()', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            pairs: [{ id: 'pair1', leftOutput: 'l', rightOutput: 'r' }],
+          }),
+      });
+      const client = new AutoblocksAppClient({ appSlug, apiKey });
+      const result = await client.humanReview.getJobPairs('job2');
+      expect(result.pairs[0].id).toBe('pair1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/apps/${appSlug}/human-review/jobs/job2/pairs`,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${apiKey}`,
+          }),
+        }),
+      );
+    });
+
+    it('calls humanReview.getJobPair()', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 'pair1',
+            leftOutput: 'l',
+            rightOutput: 'r',
+            winner: 'l',
+          }),
+      });
+      const client = new AutoblocksAppClient({ appSlug, apiKey });
+      const result = await client.humanReview.getJobPair({
+        jobId: 'job2',
+        pairId: 'pair1',
+      });
+      expect(result.id).toBe('pair1');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/apps/${appSlug}/human-review/jobs/job2/pairs/pair1`,
+        ),
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${apiKey}`,
+          }),
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
Migration from v1 to v2:
-new functionality in v2:
def get_job_test_cases(self, job_id: str):
def get_job_test_case_result(self, job_id: str, test_case_id: str):
def get_job_pairs(self, job_id: str):
def get_job_pair(self, job_id: str, pair_id: str):
update javascript-sdk:
-Added new interfaces for job test cases, test case results, job pairs, and single pair data in the human review models file
-Implemented methods in the human review client for retrieving job test cases, results, pairs, and a specific pair
-Re-exported the new types from the SDK’s main index for external use
-Created test cases validating the new methods within the application client