### PR TITLE
EPD-2117: add run_manager for V2

### DIFF
--- a/src/testing/v2/api.ts
+++ b/src/testing/v2/api.ts
@@ -69,6 +69,44 @@ export async function sendCreateHumanReviewJob(args: {
   });
 }
 
+export async function sendCreateResult(args: {
+  appSlug: string;
+  runId: string;
+  environment: string;
+  runMessage?: string;
+  startedAt: string;
+  durationMS: number;
+  status: 'SUCCESS' | 'FAILED';
+  inputRaw: string;
+  outputRaw: string;
+  input: unknown;
+  output: unknown;
+  evaluatorIdToResult: Record<string, boolean>;
+  evaluatorIdToReason: Record<string, string>;
+  evaluatorIdToScore: Record<string, number>;
+}): Promise<{ executionId: string }> {
+  const { data } = await client.postToAPI<{ executionId: string }>({
+    path: `/testing/results`,
+    body: {
+      appSlug: args.appSlug,
+      runId: args.runId,
+      environment: args.environment,
+      runMessage: args.runMessage ?? null,
+      startedAt: args.startedAt,
+      durationMS: args.durationMS,
+      status: args.status,
+      inputRaw: args.inputRaw,
+      outputRaw: args.outputRaw,
+      input: args.input,
+      output: args.output,
+      evaluatorIdToResult: args.evaluatorIdToResult,
+      evaluatorIdToReason: args.evaluatorIdToReason,
+      evaluatorIdToScore: args.evaluatorIdToScore,
+    },
+  });
+  return data;
+}
+
 export async function sendV2SlackNotification(args: {
   runId: string;
   appSlug: string;
@@ -91,7 +129,7 @@ export async function sendV2SlackNotification(args: {
     }
 
     await client.postToAPI({
-      path: `/runs/${args.runId}/slack-notification?${queryParams.toString()}`,
+      path: `/testing/runs/${args.runId}/slack-notification?${queryParams.toString()}`,
       body: {
         webhookUrl: slackWebhookUrl,
         appSlug: args.appSlug,
@@ -118,7 +156,7 @@ export async function sendV2GitHubComment(args: {
     await githubSemaphore.run(async () => {
       const queryParams = new URLSearchParams({ buildId: args.buildId });
       await client.postToAPI({
-        path: `/runs/${args.runId}/github-comment?${queryParams.toString()}`,
+        path: `/testing/runs/${args.runId}/github-comment?${queryParams.toString()}`,
         body: {
           githubToken,
           appSlug: args.appSlug,

--- a/src/testing/v2/api.ts
+++ b/src/testing/v2/api.ts
@@ -91,7 +91,7 @@ export async function sendCreateResult(args: {
       appSlug: args.appSlug,
       runId: args.runId,
       environment: args.environment,
-      runMessage: args.runMessage ?? null,
+      runMessage: args.runMessage,
       startedAt: args.startedAt,
       durationMS: args.durationMS,
       status: args.status,

--- a/src/testing/v2/index.ts
+++ b/src/testing/v2/index.ts
@@ -1,2 +1,3 @@
 export { runTestSuite } from './run';
 export { sendV2SlackNotification, sendV2GitHubComment } from './api';
+export { RunManager } from './run-manager';

--- a/src/testing/v2/run-manager.ts
+++ b/src/testing/v2/run-manager.ts
@@ -186,7 +186,7 @@ export class RunManager<TestCaseType, OutputType> {
 
   public async end(): Promise<void> {
     if (!this.startedAt) {
-      this.startedAt = nowRfc3339();
+      throw new Error('Cannot end run before starting it; call start() first.');
     }
     this.endedAt = nowRfc3339();
     this.canCreateHumanReview = true;
@@ -199,7 +199,7 @@ export class RunManager<TestCaseType, OutputType> {
   }): Promise<void> {
     if (!this.canCreateHumanReview || !this.startedAt || !this.endedAt) {
       throw new Error(
-        'Run has not ended or timestamps missing; call end() before creating human review.',
+        'Run must be started and ended before creating human review; call start() then end().',
       );
     }
 

--- a/src/testing/v2/run-manager.ts
+++ b/src/testing/v2/run-manager.ts
@@ -1,0 +1,216 @@
+import { createId } from '@paralleldrive/cuid2';
+import { BaseTestEvaluator, Evaluation } from '../models';
+import { Semaphore, determineIfEvaluationPassed } from '../util';
+import { sendCreateHumanReviewJob, sendCreateResult } from './api';
+
+type EvaluationWithId = Evaluation & { id: string };
+
+const evaluatorSemaphoreRegistry: Record<
+  string,
+  Record<string, Semaphore>
+> = {};
+
+function nowRfc3339(): string {
+  return new Date().toISOString();
+}
+
+function ensureEvaluatorSemaphores(
+  appSlug: string,
+  evaluators: Array<BaseTestEvaluator<unknown, unknown>>,
+): void {
+  if (!evaluatorSemaphoreRegistry[appSlug]) {
+    evaluatorSemaphoreRegistry[appSlug] = {};
+  }
+  const registry = evaluatorSemaphoreRegistry[appSlug];
+  for (const evaluator of evaluators) {
+    if (!registry[evaluator.id]) {
+      registry[evaluator.id] = new Semaphore(evaluator.maxConcurrency);
+    }
+  }
+}
+
+async function runEvaluator<TestCaseType, OutputType>(args: {
+  appSlug: string;
+  testCase: TestCaseType;
+  output: OutputType;
+  evaluator: BaseTestEvaluator<TestCaseType, OutputType>;
+}): Promise<EvaluationWithId | undefined> {
+  const semaphore =
+    evaluatorSemaphoreRegistry[args.appSlug]?.[args.evaluator.id];
+  if (!semaphore) {
+    throw new Error(
+      `[${args.appSlug}] Evaluator semaphore not found for '${args.evaluator.id}'.`,
+    );
+  }
+
+  return await semaphore.run(async () => {
+    const evaluation = await args.evaluator.evaluateTestCase({
+      testCase: args.testCase,
+      output: args.output,
+    });
+    if (evaluation === undefined) {
+      return undefined;
+    }
+    return { id: args.evaluator.id, ...evaluation };
+  });
+}
+
+function makeEvaluatorMaps(evals: EvaluationWithId[]): {
+  result: Record<string, boolean>;
+  reason: Record<string, string>;
+  score: Record<string, number>;
+} {
+  const idToResult: Record<string, boolean> = {};
+  const idToReason: Record<string, string> = {};
+  const idToScore: Record<string, number> = {};
+
+  for (const e of evals) {
+    const passed = determineIfEvaluationPassed({ evaluation: e });
+    idToResult[e.id] = Boolean(passed);
+
+    let reason = '';
+    const metadataReason =
+      typeof e.metadata === 'object' && e.metadata !== null
+        ? (e.metadata as Record<string, unknown>).reason
+        : undefined;
+    if (typeof metadataReason === 'string' && metadataReason) {
+      reason = metadataReason;
+    }
+
+    if (!reason && Array.isArray(e.assertions)) {
+      for (const assertion of e.assertions) {
+        if (!assertion.passed) {
+          const aMeta = assertion.metadata as
+            | Record<string, unknown>
+            | undefined;
+          const msg = aMeta?.message ?? aMeta?.reason;
+          if (typeof msg === 'string' && msg) {
+            reason = msg;
+            break;
+          }
+        }
+      }
+    }
+
+    idToReason[e.id] = reason;
+    idToScore[e.id] = e.score;
+  }
+
+  return { result: idToResult, reason: idToReason, score: idToScore };
+}
+
+export class RunManager<TestCaseType, OutputType> {
+  appSlug: string;
+  environment: string;
+  runMessage?: string;
+  runId: string;
+  startedAt?: string;
+  endedAt?: string;
+  canCreateHumanReview: boolean = false;
+
+  constructor(args: {
+    appSlug: string;
+    environment?: string;
+    runMessage?: string;
+  }) {
+    this.appSlug = args.appSlug;
+    this.environment = args.environment ?? 'test';
+    this.runMessage = args.runMessage;
+    this.runId = createId();
+  }
+
+  public async start(): Promise<void> {
+    this.startedAt = nowRfc3339();
+  }
+
+  public async addResult(args: {
+    testCase: TestCaseType;
+    output: OutputType;
+    durationMs: number;
+    evaluators?: Array<BaseTestEvaluator<TestCaseType, OutputType>>;
+    status?: 'SUCCESS' | 'FAILED';
+    startedAt?: string;
+  }): Promise<string> {
+    if (this.endedAt) {
+      throw new Error('You cannot add results to an ended run.');
+    }
+
+    const inputRaw = JSON.stringify(args.testCase);
+    const outputRaw = JSON.stringify(args.output);
+
+    const evaluators = args.evaluators || [];
+    ensureEvaluatorSemaphores(
+      this.appSlug,
+      evaluators as Array<BaseTestEvaluator<unknown, unknown>>,
+    );
+
+    const results = await Promise.allSettled(
+      evaluators.map((e) =>
+        runEvaluator<TestCaseType, OutputType>({
+          appSlug: this.appSlug,
+          testCase: args.testCase,
+          output: args.output,
+          evaluator: e,
+        }),
+      ),
+    );
+
+    const fulfilled: EvaluationWithId[] = [];
+    for (const r of results) {
+      if (r.status === 'fulfilled' && r.value) {
+        fulfilled.push(r.value);
+      }
+    }
+    const { result, reason, score } = makeEvaluatorMaps(fulfilled);
+
+    const startedAt = args.startedAt ?? nowRfc3339();
+    const resp = await sendCreateResult({
+      appSlug: this.appSlug,
+      runId: this.runId,
+      environment: this.environment,
+      runMessage: this.runMessage,
+      startedAt,
+      durationMS: args.durationMs,
+      status: args.status ?? 'SUCCESS',
+      inputRaw,
+      outputRaw,
+      input: args.testCase as unknown,
+      output: args.output as unknown,
+      evaluatorIdToResult: result,
+      evaluatorIdToReason: reason,
+      evaluatorIdToScore: score,
+    });
+
+    return resp.executionId;
+  }
+
+  public async end(): Promise<void> {
+    if (!this.startedAt) {
+      this.startedAt = nowRfc3339();
+    }
+    this.endedAt = nowRfc3339();
+    this.canCreateHumanReview = true;
+  }
+
+  public async createHumanReview(args: {
+    name: string;
+    assigneeEmailAddresses: string[];
+    rubricId?: string;
+  }): Promise<void> {
+    if (!this.canCreateHumanReview || !this.startedAt || !this.endedAt) {
+      throw new Error(
+        'Run has not ended or timestamps missing; call end() before creating human review.',
+      );
+    }
+
+    await sendCreateHumanReviewJob({
+      appSlug: this.appSlug,
+      runId: this.runId,
+      name: args.name,
+      assigneeEmailAddresses: args.assigneeEmailAddresses,
+      rubricId: args.rubricId,
+      startTimestamp: this.startedAt,
+      endTimestamp: this.endedAt,
+    });
+  }
+}

--- a/test/testing/run-manager-v2.spec.ts
+++ b/test/testing/run-manager-v2.spec.ts
@@ -120,29 +120,9 @@ describe('RunManager V2', () => {
     expect(typeof hrBody.endTimestamp).toBe('string');
   });
 
-  it('end without start sets timestamps and allows human review', async () => {
+  it('end without start throws', async () => {
     const rm = new RunManager<MyTestCase, MyOutput>({ appSlug: 'my-app' });
-    await rm.end();
-    expect(rm.canCreateHumanReview).toBe(true);
-    expect(rm.startedAt).toBeDefined();
-    expect(rm.endedAt).toBeDefined();
-
-    await rm.createHumanReview({
-      name: 'HR job',
-      assigneeEmailAddresses: ['a@test.com'],
-    });
-    const fetchCalls = (global.fetch as unknown as jest.Mock).mock.calls;
-    const hrCall = fetchCalls.find((c) =>
-      c[0].toString().includes('/human-review/jobs'),
-    )!;
-    const hrBody = JSON.parse(hrCall[1].body);
-    expect(hrBody).toMatchObject({
-      runId: rm.runId,
-      assigneeEmailAddresses: ['a@test.com'],
-      name: 'HR job',
-    });
-    expect(typeof hrBody.startTimestamp).toBe('string');
-    expect(typeof hrBody.endTimestamp).toBe('string');
+    await expect(rm.end()).rejects.toThrow(/start\(\) first/i);
   });
 
   it('addResult without evaluators sends empty maps', async () => {

--- a/test/testing/run-manager-v2.spec.ts
+++ b/test/testing/run-manager-v2.spec.ts
@@ -1,0 +1,166 @@
+import { RunManager } from '../../src/testing/v2';
+import { AutoblocksEnvVar } from '../../src/util';
+import { BaseTestEvaluator } from '../../src/testing/models';
+
+interface MyTestCase {
+  input: string;
+}
+interface MyOutput {
+  output: string;
+}
+
+class MyEvaluator extends BaseTestEvaluator<MyTestCase, MyOutput> {
+  get id() {
+    return 'evaluator-external-id';
+  }
+  evaluateTestCase() {
+    return { score: 1, threshold: { gte: 0.5 }, metadata: { reason: 'ok' } };
+  }
+}
+
+describe('RunManager V2', () => {
+  const mockAPIKey = 'mock-v2-api-key';
+
+  beforeEach(() => {
+    process.env[AutoblocksEnvVar.AUTOBLOCKS_V2_API_KEY] = mockAPIKey;
+    // @ts-expect-error set fetch mock
+    global.fetch = jest.fn(async (url: string) => {
+      if (url.toString().endsWith('/testing/results')) {
+        return {
+          ok: true,
+          json: async () => ({ executionId: 'mock-exec-id' }),
+          status: 200,
+          statusText: 'OK',
+        } as unknown as Response;
+      }
+      if (url.toString().includes('/human-review/jobs')) {
+        return {
+          ok: true,
+          json: async () => ({}),
+          status: 200,
+          statusText: 'OK',
+        } as unknown as Response;
+      }
+      throw new Error(`Unknown URL: ${url}`);
+    });
+  });
+
+  afterEach(() => {
+    delete process.env[AutoblocksEnvVar.AUTOBLOCKS_V2_API_KEY];
+    jest.clearAllMocks();
+  });
+
+  it('does not allow adding result after run has ended', async () => {
+    const rm = new RunManager<MyTestCase, MyOutput>({
+      appSlug: 'my-app',
+      runMessage: 'Test run',
+    });
+    await rm.start();
+    await rm.end();
+    await expect(
+      rm.addResult({
+        testCase: { input: 'test' },
+        output: { output: 'test' },
+        durationMs: 100,
+      }),
+    ).rejects.toThrow(/ended run/i);
+  });
+
+  it('full lifecycle v2', async () => {
+    const rm = new RunManager<MyTestCase, MyOutput>({
+      appSlug: 'my-app',
+      runMessage: 'Test run',
+    });
+    await rm.start();
+    const execId = await rm.addResult({
+      testCase: { input: 'test' },
+      output: { output: 'test' },
+      durationMs: 100,
+      evaluators: [new MyEvaluator()],
+      startedAt: '2025-01-01T00:00:00.000Z',
+    });
+    expect(execId).toBe('mock-exec-id');
+
+    const fetchCalls = (global.fetch as unknown as jest.Mock).mock.calls;
+    const createResultCall = fetchCalls.find((c) =>
+      c[0].toString().endsWith('/testing/results'),
+    )!;
+    const body = JSON.parse(createResultCall[1].body);
+    expect(body).toMatchObject({
+      appSlug: 'my-app',
+      environment: 'test',
+      runMessage: 'Test run',
+      startedAt: '2025-01-01T00:00:00.000Z',
+      durationMS: 100,
+      status: 'SUCCESS',
+      inputRaw: JSON.stringify({ input: 'test' }),
+      outputRaw: JSON.stringify({ output: 'test' }),
+      input: { input: 'test' },
+      output: { output: 'test' },
+      evaluatorIdToResult: { 'evaluator-external-id': true },
+      evaluatorIdToReason: { 'evaluator-external-id': 'ok' },
+      evaluatorIdToScore: { 'evaluator-external-id': 1 },
+    });
+
+    await rm.end();
+    await rm.createHumanReview({
+      name: 'Test human review job',
+      assigneeEmailAddresses: ['test@test.com'],
+    });
+    const hrCall = fetchCalls.find((c) =>
+      c[0].toString().includes('/human-review/jobs'),
+    )!;
+    const hrBody = JSON.parse(hrCall[1].body);
+    expect(hrBody).toMatchObject({
+      runId: rm.runId,
+      assigneeEmailAddresses: ['test@test.com'],
+      name: 'Test human review job',
+    });
+    expect(typeof hrBody.startTimestamp).toBe('string');
+    expect(typeof hrBody.endTimestamp).toBe('string');
+  });
+
+  it('end without start sets timestamps and allows human review', async () => {
+    const rm = new RunManager<MyTestCase, MyOutput>({ appSlug: 'my-app' });
+    await rm.end();
+    expect(rm.canCreateHumanReview).toBe(true);
+    expect(rm.startedAt).toBeDefined();
+    expect(rm.endedAt).toBeDefined();
+
+    await rm.createHumanReview({
+      name: 'HR job',
+      assigneeEmailAddresses: ['a@test.com'],
+    });
+    const fetchCalls = (global.fetch as unknown as jest.Mock).mock.calls;
+    const hrCall = fetchCalls.find((c) =>
+      c[0].toString().includes('/human-review/jobs'),
+    )!;
+    const hrBody = JSON.parse(hrCall[1].body);
+    expect(hrBody).toMatchObject({
+      runId: rm.runId,
+      assigneeEmailAddresses: ['a@test.com'],
+      name: 'HR job',
+    });
+    expect(typeof hrBody.startTimestamp).toBe('string');
+    expect(typeof hrBody.endTimestamp).toBe('string');
+  });
+
+  it('addResult without evaluators sends empty maps', async () => {
+    const rm = new RunManager<MyTestCase, MyOutput>({ appSlug: 'my-app' });
+    await rm.start();
+    const execId = await rm.addResult({
+      testCase: { input: 'test' },
+      output: { output: 'test' },
+      durationMs: 250,
+    });
+    expect(execId).toBe('mock-exec-id');
+    const fetchCalls = (global.fetch as unknown as jest.Mock).mock.calls;
+    const createResultCall = fetchCalls.find((c) =>
+      c[0].toString().endsWith('/testing/results'),
+    )!;
+    const body = JSON.parse(createResultCall[1].body);
+    expect(body.evaluatorIdToResult).toEqual({});
+    expect(body.evaluatorIdToReason).toEqual({});
+    expect(body.evaluatorIdToScore).toEqual({});
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR introduces a V2 implementation of the RunManager class for the testing framework, representing a significant architectural shift toward a more streamlined testing workflow. The key changes include:

**New V2 RunManager Implementation** (`src/testing/v2/run-manager.ts`): This new class simplifies the testing API by consolidating multiple V1 operations into single API calls. Unlike V1 which requires separate calls to start runs, add test cases, outputs, and evaluations, V2 combines these into a single `sendCreateResult` call. The V2 implementation includes built-in evaluator execution with semaphore-based concurrency control, automatic timestamp management, and support for multiple assignees in human review workflows.

**Enhanced V2 API Support** (`src/testing/v2/api.ts`): Adds the `sendCreateResult` function that accepts comprehensive test execution data including evaluator results, timing information, and serialized input/output in a single API call. The PR also fixes URL paths for Slack and GitHub notification endpoints by adding the `/testing` prefix for V2 API consistency.

**Public API Export** (`src/testing/v2/index.ts`): Exposes the new RunManager as part of the public V2 testing API, making it available for external consumption.

**Comprehensive Test Coverage** (`test/testing/run-manager-v2.spec.ts`): Provides full test coverage for the V2 RunManager, including lifecycle operations, error handling for invalid state transitions, and human review functionality. The tests adapt to the simplified V2 API structure while maintaining similar behavioral expectations as V1.

This V2 architecture reduces API complexity and network overhead by eliminating multiple round-trips, while adding enhanced features like built-in evaluator management and improved human review capabilities. The implementation maintains the core RunManager contract while providing a more efficient and user-friendly interface.

## Confidence score: 3/5

- This PR introduces significant architectural changes with some potential lifecycle management issues that could confuse users
- Score reflects concerns about the `end()` method automatically setting `startedAt` if not already set, and the `start()` method only setting timestamps without server interaction
- Pay close attention to `src/testing/v2/run-manager.ts` lifecycle methods and ensure the implicit run creation behavior is well documented

<!-- /greptile_comment -->